### PR TITLE
Feature/nfpa 84 env variables from beanstalk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,15 @@
   "requires": true,
   "dependencies": {
     "and-cli": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/and-cli/-/and-cli-0.0.5.tgz",
-      "integrity": "sha512-iXIDBu5FAfqySnx5qupQN4JNkIYDwhjo1mEewAPW8U3SN3XkZe6wQ7TgqDuTRIEHkUniGrh7gND7Nyk5fxjoww==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/and-cli/-/and-cli-0.0.7.tgz",
+      "integrity": "sha512-G67Db4OJXcLRgrtxHzIH9FkaKnHJf4aQRctKcHHjUm8Q80LonZIPuoULfjTuna10k187fXQCXHP02gE2AJgNcQ==",
       "dev": true,
       "requires": {
+        "archiver": "3.1.1",
         "chalk": "^2.4.1",
         "commander": "^2.15.1",
+        "require-all": "3.0.0",
         "shelljs": "^0.8.2",
         "upath": "^1.1.2"
       }
@@ -25,11 +27,85 @@
         "color-convert": "^1.9.0"
       }
     },
+    "archiver": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
+      "integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "async": "^2.6.3",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.1.4",
+        "readable-stream": "^3.4.0",
+        "tar-stream": "^2.1.0",
+        "zip-stream": "^2.1.2"
+      }
+    },
+    "archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        }
+      }
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
+    },
+    "bl": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^3.0.1"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -40,6 +116,22 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "buffer": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
@@ -73,16 +165,85 @@
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
       "dev": true
     },
+    "compress-commons": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
+      "integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^3.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.3.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "crc32-stream": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+      "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
+      "dev": true,
+      "requires": {
+        "crc": "^3.4.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
     "fs.realpath": {
@@ -105,10 +266,22 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
       "dev": true
     },
     "inflight": {
@@ -133,6 +306,74 @@
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.5"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -141,6 +382,12 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -163,6 +410,23 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+      "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -172,6 +436,12 @@
         "resolve": "^1.1.6"
       }
     },
+    "require-all": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/require-all/-/require-all-3.0.0.tgz",
+      "integrity": "sha1-Rz1JcEvjEBFc4ST3c4Ox69hnExI=",
+      "dev": true
+    },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
@@ -180,6 +450,12 @@
       "requires": {
         "path-parse": "^1.0.6"
       }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "shelljs": {
       "version": "0.8.3",
@@ -192,6 +468,15 @@
         "rechoir": "^0.6.2"
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -201,10 +486,29 @@
         "has-flag": "^3.0.0"
       }
     },
+    "tar-stream": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+      "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+      "dev": true,
+      "requires": {
+        "bl": "^3.0.0",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "upath": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
-      "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "wrappy": {
@@ -212,6 +516,17 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "zip-stream": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.2.tgz",
+      "integrity": "sha512-ykebHGa2+uzth/R4HZLkZh3XFJzivhVsjJt8bN3GvBzLaqqrUdRacu+c4QtnUgjkkQfsOuNE1JgLKMCPNmkKgg==",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^2.1.1",
+        "readable-stream": "^3.4.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "license": "ISC",
   "homepage": "https://github.com/AndcultureCode/AndcultureCode.CSharp.Core#readme",
   "devDependencies": {
-    "and-cli": "0.0.5"
+    "and-cli": "0.0.7"
   }
 }

--- a/src/AndcultureCode.CSharp.Core/AndcultureCode.CSharp.Core.csproj
+++ b/src/AndcultureCode.CSharp.Core/AndcultureCode.CSharp.Core.csproj
@@ -9,11 +9,13 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/AndcultureCode/AndcultureCode.CSharp.Core</PackageProjectUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.1.1</Version>
+    <Version>0.1.2</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AndcultureCode.CSharp.Extensions" Version="0.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/AndcultureCode.CSharp.Core/AndcultureCode.CSharp.Core.csproj
+++ b/src/AndcultureCode.CSharp.Core/AndcultureCode.CSharp.Core.csproj
@@ -9,7 +9,7 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/AndcultureCode/AndcultureCode.CSharp.Core</PackageProjectUrl>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.1.2</Version>
+    <Version>0.2.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AndcultureCode.CSharp.Core/Extensions/IAndcultureCodeWebHostBuilderExtensions.cs
+++ b/src/AndcultureCode.CSharp.Core/Extensions/IAndcultureCodeWebHostBuilderExtensions.cs
@@ -1,0 +1,39 @@
+using System;
+using AndcultureCode.CSharp.Core.Interfaces.Hosting;
+using AndcultureCode.CSharp.Core.Utilities.Configuration;
+
+namespace AndcultureCode.CSharp.Core.Extensions
+{
+    public static class IAndcultureCodeWebHostBuilderExtensions
+    {
+        #region Constants
+
+        private const string ASPNETCORE_ENVIRONMENT = "ASPNETCORE_ENVIRONMENT";
+
+        #endregion Constants
+
+
+        #region Public Methods
+
+        /// <summary>
+        /// Configures resources from Amazon Elastic Beanstalk (EB) before AspNetCore
+        /// is started up. Namely, reading of ASPNET environment
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="stdoutEnabled">Should errors be output to standard output for debugging being this could be run before logging starts</param>
+        /// <returns></returns>
+        public static IAndcultureCodeWebHostBuilder PreloadAmazonElasticBeanstalk(this IAndcultureCodeWebHostBuilder builder, bool stdoutEnabled = false)
+        {
+            var ebProvider = new AmazonEBConfigurationProvider(stdoutEnabled);
+            if (ebProvider.Has(ASPNETCORE_ENVIRONMENT))
+            {
+                var ebEnvironment = ebProvider.Get(ASPNETCORE_ENVIRONMENT);
+                Environment.SetEnvironmentVariable(ASPNETCORE_ENVIRONMENT, ebEnvironment);
+            }
+
+            return builder;
+        }
+
+        #endregion Public Methods
+    }
+}

--- a/src/AndcultureCode.CSharp.Core/Extensions/IAndcultureCodeWebHostBuilderExtensions.cs
+++ b/src/AndcultureCode.CSharp.Core/Extensions/IAndcultureCodeWebHostBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace AndcultureCode.CSharp.Core.Extensions
     {
         #region Constants
 
-        private const string ASPNETCORE_ENVIRONMENT = "ASPNETCORE_ENVIRONMENT";
+        public const string ASPNETCORE_ENVIRONMENT = "ASPNETCORE_ENVIRONMENT";
 
         #endregion Constants
 
@@ -22,9 +22,12 @@ namespace AndcultureCode.CSharp.Core.Extensions
         /// <param name="builder"></param>
         /// <param name="stdoutEnabled">Should errors be output to standard output for debugging being this could be run before logging starts</param>
         /// <returns></returns>
-        public static IAndcultureCodeWebHostBuilder PreloadAmazonElasticBeanstalk(this IAndcultureCodeWebHostBuilder builder, bool stdoutEnabled = false)
+        public static IAndcultureCodeWebHostBuilder PreloadAmazonElasticBeanstalk(
+            this IAndcultureCodeWebHostBuilder builder,
+            bool                               stdoutEnabled = false,
+            AmazonEBConfigurationProvider      configurationProvider = null)
         {
-            var ebProvider = new AmazonEBConfigurationProvider(stdoutEnabled);
+            var ebProvider = configurationProvider ?? new AmazonEBConfigurationProvider(stdoutEnabled);
             if (ebProvider.Has(ASPNETCORE_ENVIRONMENT))
             {
                 var ebEnvironment = ebProvider.Get(ASPNETCORE_ENVIRONMENT);

--- a/src/AndcultureCode.CSharp.Core/Extensions/IConfigurationBuilderExtensions.cs
+++ b/src/AndcultureCode.CSharp.Core/Extensions/IConfigurationBuilderExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Configuration;
+using AndcultureCode.CSharp.Core.Utilities.Configuration;
+
+namespace AndcultureCode.CSharp.Core.Extensions
+{
+    public static class IConfigurationBuilderExtensions
+    {
+        /// <summary>
+        /// Configures dotnet IConfigurationBuilder to read Amazon Elastic Beanstalk instance environment variables
+        /// </summary>
+        /// <param name="configurationBuilder"></param>
+        /// <returns></returns>
+        /// <example>
+        /// <code>
+        /// new ConfigurationBuilder()
+        ///     .AddJsonFile("appsettings.json")
+        ///     .AddAmazonElasticBeanstalk()
+        ///     .AddEnvironmentVariables();
+        /// </code>
+        /// </example>
+        public static IConfigurationBuilder AddAmazonElasticBeanstalk(this IConfigurationBuilder configurationBuilder)
+        {
+            configurationBuilder.Add(new AmazonEBConfigurationSource());
+            return configurationBuilder;
+        }
+    }
+}

--- a/src/AndcultureCode.CSharp.Core/Interfaces/Hosting/IAndcultureCodeWebHostBuilder.cs
+++ b/src/AndcultureCode.CSharp.Core/Interfaces/Hosting/IAndcultureCodeWebHostBuilder.cs
@@ -6,6 +6,9 @@ namespace AndcultureCode.CSharp.Core.Interfaces.Hosting
     {
         #region Properties
 
+        /// <summary>
+        /// The command line args to dotnet process. Ultimately piped to AspNetCore WebHost.
+        /// </summary>
         string[] Args { get; set; }
 
         #endregion Properties

--- a/src/AndcultureCode.CSharp.Core/Interfaces/Hosting/IAndcultureCodeWebHostBuilder.cs
+++ b/src/AndcultureCode.CSharp.Core/Interfaces/Hosting/IAndcultureCodeWebHostBuilder.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Hosting;
+
+namespace AndcultureCode.CSharp.Core.Interfaces.Hosting
+{
+    public interface IAndcultureCodeWebHostBuilder
+    {
+        #region Properties
+
+        string[] Args { get; set; }
+
+        #endregion Properties
+
+
+        #region Methods
+
+        /// <summary>
+        /// Simple wrapper around AspNetCore WebHost.CreateDefaultBuilder
+        /// to support our own extensibility model
+        /// </summary>
+        /// <returns></returns>
+        IWebHostBuilder CreateDefaultBuilder();
+
+        #endregion Methods
+    }
+}

--- a/src/AndcultureCode.CSharp.Core/Models/Hosting/AndcultureCodeWebHostBuilder.cs
+++ b/src/AndcultureCode.CSharp.Core/Models/Hosting/AndcultureCodeWebHostBuilder.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using AndcultureCode.CSharp.Core.Interfaces.Hosting;
+
+namespace AndcultureCode.CSharp.Core.Models.Hosting
+{
+    public class AndcultureCodeWebHostBuilder : IAndcultureCodeWebHostBuilder
+    {
+        #region Properties
+
+        /// <summary>
+        /// The command line args to dotnet process. Ultimately piped to AspNetCore WebHost.
+        /// </summary>
+        public string[] Args { get; set; }
+
+        #endregion Properties
+
+
+        #region Constructors
+
+        public AndcultureCodeWebHostBuilder() {}
+        public AndcultureCodeWebHostBuilder(string[] args)
+        {
+            Args = args;
+        }
+
+        #endregion Constructors
+
+
+        #region Public Methods
+
+        public IWebHostBuilder CreateDefaultBuilder() => WebHost.CreateDefaultBuilder(Args);
+
+        #endregion Public Methods
+    }
+}

--- a/src/AndcultureCode.CSharp.Core/Models/Hosting/AndcultureCodeWebHostBuilder.cs
+++ b/src/AndcultureCode.CSharp.Core/Models/Hosting/AndcultureCodeWebHostBuilder.cs
@@ -8,9 +8,6 @@ namespace AndcultureCode.CSharp.Core.Models.Hosting
     {
         #region Properties
 
-        /// <summary>
-        /// The command line args to dotnet process. Ultimately piped to AspNetCore WebHost.
-        /// </summary>
         public string[] Args { get; set; }
 
         #endregion Properties

--- a/src/AndcultureCode.CSharp.Core/Utilities/Configuration/AmazonEBConfigurationProvider.cs
+++ b/src/AndcultureCode.CSharp.Core/Utilities/Configuration/AmazonEBConfigurationProvider.cs
@@ -1,0 +1,135 @@
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace AndcultureCode.CSharp.Core.Utilities.Configuration
+{
+    /// <summary>
+    /// Adds support to read environment variables from an Amazon Elastic Beanstalk EC2 instance
+    ///
+    /// At this time AWS stores these environment variables in its own proprietary configuration
+    /// that we are forced to read and pipe to the application.
+    /// </summary>
+    public class AmazonEBConfigurationProvider : ConfigurationProvider
+    {
+        #region Constants
+
+        /// <summary>
+        /// Absolute path to the AWS Elastic Beanstalk windows instance configuration file
+        /// </summary>
+        private const string CONFIGURATION_FILE_PATH = @"C:\Program Files\Amazon\ElasticBeanstalk\config\containerconfiguration";
+
+        #endregion Constants
+
+
+        #region Properties
+
+        private bool StdoutEnabled { get; set; }
+
+        #endregion Properties
+
+
+        #region Constructors
+
+        public AmazonEBConfigurationProvider(bool stdoutEnabled = false)
+        {
+            StdoutEnabled = stdoutEnabled;
+        }
+
+        #endregion Constructors
+
+
+        #region Properties
+
+        public static IDictionary<string, string> CachedConfiguration { get; set; }
+
+        #endregion Properties
+
+
+        #region Public Methods
+
+        public string Get(string key) => ReadConfiguration()[key];
+
+        public bool Has(string key) => ReadConfiguration().ContainsKey(key);
+
+        public IDictionary<string, string> ReadConfiguration()
+        {
+            if (CachedConfiguration != null)
+            {
+                return CachedConfiguration;
+            }
+
+            var result = new Dictionary<string, string>();
+
+            if (!File.Exists(CONFIGURATION_FILE_PATH))
+            {
+                LogIfEnabled($"File '{CONFIGURATION_FILE_PATH}' does not exist");
+                return result;
+            }
+
+            string configJson;
+            try
+            {
+                configJson = File.ReadAllText(CONFIGURATION_FILE_PATH);
+            }
+            catch(Exception ex)
+            {
+                LogIfEnabled($"Failed to read file contents '{CONFIGURATION_FILE_PATH}' - {ex.Message}");
+                return result;
+            }
+
+            var config = JObject.Parse(configJson);
+            var env    = (JArray)config["iis"]["env"];
+
+            if (env.Count == 0)
+            {
+                LogIfEnabled("No environment variables found");
+                return result;
+            }
+
+            foreach (var item in env.Select(i => (string)i))
+            {
+                int eqIndex = item.IndexOf('=');
+                var key     = item.Substring(0, eqIndex);
+                var value   = item.Substring(eqIndex + 1);
+                key         = key.Replace("__", ":"); // Need to translate so inheritance is respected (addition to fix the gist in github)
+                result[key] = value;
+            }
+
+            CachedConfiguration = result;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Load the configuration into the inherited 'Data' dictionary for use by ConfigurationRoot/Builder
+        /// </summary>
+        public override void Load()
+        {
+            foreach (var entry in ReadConfiguration())
+            {
+                Data[entry.Key] = entry.Value;
+            }
+        }
+
+        #endregion Public Methods
+
+
+        #region Private Methods
+
+        private void LogIfEnabled(string message)
+        {
+            if (!StdoutEnabled)
+            {
+                return;
+            }
+
+            Console.WriteLine($"[AmazonEBConfigurationProvider] {message}");
+        }
+
+        #endregion Private Methods
+    }
+}

--- a/src/AndcultureCode.CSharp.Core/Utilities/Configuration/AmazonEBConfigurationProvider.cs
+++ b/src/AndcultureCode.CSharp.Core/Utilities/Configuration/AmazonEBConfigurationProvider.cs
@@ -54,11 +54,11 @@ namespace AndcultureCode.CSharp.Core.Utilities.Configuration
 
         #region Public Methods
 
-        public virtual string Get(string key) => Has(key) ? ReadConfiguration()[key] : null;
+        public virtual string Get(string key) => Has(key) ? Read()[key] : null;
 
-        public virtual bool Has(string key) => ReadConfiguration().ContainsKey(key);
+        public virtual bool Has(string key) => Read().ContainsKey(key);
 
-        public virtual IDictionary<string, string> ReadConfiguration()
+        public virtual IDictionary<string, string> Read()
         {
             if (CachedConfiguration != null)
             {
@@ -112,7 +112,7 @@ namespace AndcultureCode.CSharp.Core.Utilities.Configuration
         /// </summary>
         public override void Load()
         {
-            foreach (var entry in ReadConfiguration())
+            foreach (var entry in Read())
             {
                 Data[entry.Key] = entry.Value;
             }

--- a/src/AndcultureCode.CSharp.Core/Utilities/Configuration/AmazonEBConfigurationProvider.cs
+++ b/src/AndcultureCode.CSharp.Core/Utilities/Configuration/AmazonEBConfigurationProvider.cs
@@ -34,6 +34,7 @@ namespace AndcultureCode.CSharp.Core.Utilities.Configuration
 
         #region Constructors
 
+        public AmazonEBConfigurationProvider() {}
         public AmazonEBConfigurationProvider(bool stdoutEnabled = false)
         {
             StdoutEnabled = stdoutEnabled;
@@ -51,11 +52,11 @@ namespace AndcultureCode.CSharp.Core.Utilities.Configuration
 
         #region Public Methods
 
-        public string Get(string key) => ReadConfiguration()[key];
+        public string Get(string key) => Has(key) ? ReadConfiguration()[key] : null;
 
         public bool Has(string key) => ReadConfiguration().ContainsKey(key);
 
-        public IDictionary<string, string> ReadConfiguration()
+        public virtual IDictionary<string, string> ReadConfiguration()
         {
             if (CachedConfiguration != null)
             {

--- a/src/AndcultureCode.CSharp.Core/Utilities/Configuration/AmazonEBConfigurationProvider.cs
+++ b/src/AndcultureCode.CSharp.Core/Utilities/Configuration/AmazonEBConfigurationProvider.cs
@@ -52,9 +52,9 @@ namespace AndcultureCode.CSharp.Core.Utilities.Configuration
 
         #region Public Methods
 
-        public string Get(string key) => Has(key) ? ReadConfiguration()[key] : null;
+        public virtual string Get(string key) => Has(key) ? ReadConfiguration()[key] : null;
 
-        public bool Has(string key) => ReadConfiguration().ContainsKey(key);
+        public virtual bool Has(string key) => ReadConfiguration().ContainsKey(key);
 
         public virtual IDictionary<string, string> ReadConfiguration()
         {

--- a/src/AndcultureCode.CSharp.Core/Utilities/Configuration/AmazonEBConfigurationProvider.cs
+++ b/src/AndcultureCode.CSharp.Core/Utilities/Configuration/AmazonEBConfigurationProvider.cs
@@ -45,7 +45,7 @@ namespace AndcultureCode.CSharp.Core.Utilities.Configuration
 
         #region Properties
 
-        public static IDictionary<string, string> CachedConfiguration { get; set; }
+        public IDictionary<string, string> CachedConfiguration { get; set; }
 
         #endregion Properties
 

--- a/src/AndcultureCode.CSharp.Core/Utilities/Configuration/AmazonEBConfigurationSource.cs
+++ b/src/AndcultureCode.CSharp.Core/Utilities/Configuration/AmazonEBConfigurationSource.cs
@@ -1,0 +1,9 @@
+using Microsoft.Extensions.Configuration;
+
+namespace AndcultureCode.CSharp.Core.Utilities.Configuration
+{
+    public class AmazonEBConfigurationSource : IConfigurationSource
+    {
+        public IConfigurationProvider Build(IConfigurationBuilder builder) => new AmazonEBConfigurationProvider();
+    }
+}

--- a/src/AndcultureCode.CSharp.Core/Utilities/Hosting/AndcultureCodeWebHost.cs
+++ b/src/AndcultureCode.CSharp.Core/Utilities/Hosting/AndcultureCodeWebHost.cs
@@ -1,0 +1,15 @@
+using AndcultureCode.CSharp.Core.Interfaces.Hosting;
+using AndcultureCode.CSharp.Core.Models.Hosting;
+
+namespace AndcultureCode.CSharp.Core.Utilities.Hosting
+{
+    public static class AndcultureCodeWebHost
+    {
+        /// <summary>
+        /// Entry point to our custom WebHost builder pattern.
+        /// From here extensions methods can but hung off of IAndcultureCodeWebHostBuilder
+        /// </summary>
+        /// <returns></returns>
+        public static IAndcultureCodeWebHostBuilder Preload(string[] args) => new AndcultureCodeWebHostBuilder(args);
+    }
+}

--- a/test/AndcultureCode.CSharp.Core.Tests/Extensions/IAndcultureCodeWebHostBuilderExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Extensions/IAndcultureCodeWebHostBuilderExtensionsTest.cs
@@ -9,6 +9,9 @@ using AndcultureCode.CSharp.Core.Models;
 using AndcultureCode.CSharp.Core.Extensions;
 using AndcultureCode.CSharp.Core.Interfaces;
 using AndcultureCode.CSharp.Core.Enumerations;
+using AndcultureCode.CSharp.Core.Interfaces.Hosting;
+using AndcultureCode.CSharp.Core.Utilities.Configuration;
+using Moq;
 
 namespace AndcultureCode.CSharp.Core.Tests.Unit.Extensions
 {
@@ -23,10 +26,41 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Extensions
 
         #region PreloadAmazonElasticBeanstalk
 
-        [Fact(Skip = "TODO: NFPA-84")]
-        public void PreloadAmazonElasticBeanstalk_Write_Tests()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void PreloadAmazonElasticBeanstalk_With_Default_Arguments_Returns_Builder(bool stdoutEnabled)
         {
-            true.ShouldBeFalse();
+            // Arrange
+            var mockBuilder = new Mock<IAndcultureCodeWebHostBuilder>();
+
+            // Act
+            var result = IAndcultureCodeWebHostBuilderExtensions.PreloadAmazonElasticBeanstalk(mockBuilder.Object, stdoutEnabled);
+
+            // Assert
+            result.ShouldBe(mockBuilder.Object);
+        }
+
+        [Fact]
+        public void PreloadAmazonElasticBeanstalk_When_Contains_AspNetCore_Environment_Sets_Global_EnvironmentVariable()
+        {
+            // Arrange
+            var expected     = Random.String();
+            var mockBuilder  = new Mock<IAndcultureCodeWebHostBuilder>();
+            var mockProvider = new Mock<AmazonEBConfigurationProvider>();
+            mockProvider.Setup(e => e.Has(IAndcultureCodeWebHostBuilderExtensions.ASPNETCORE_ENVIRONMENT)).Returns(true);
+            mockProvider.Setup(e => e.Get(IAndcultureCodeWebHostBuilderExtensions.ASPNETCORE_ENVIRONMENT)).Returns(expected);
+
+            // Act
+            var result = IAndcultureCodeWebHostBuilderExtensions.PreloadAmazonElasticBeanstalk(
+                mockBuilder.Object,
+                stdoutEnabled: false,
+                configurationProvider: mockProvider.Object
+            );
+
+            // Assert
+            result.ShouldNotBeNull();
+            Environment.GetEnvironmentVariable(IAndcultureCodeWebHostBuilderExtensions.ASPNETCORE_ENVIRONMENT).ShouldBe(expected);
         }
 
         #endregion PreloadAmazonElasticBeanstalk

--- a/test/AndcultureCode.CSharp.Core.Tests/Extensions/IAndcultureCodeWebHostBuilderExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Extensions/IAndcultureCodeWebHostBuilderExtensionsTest.cs
@@ -1,0 +1,34 @@
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+using AndcultureCode.CSharp.Testing;
+using AndcultureCode.CSharp.Testing.Extensions;
+using AndcultureCode.CSharp.Core.Models;
+using AndcultureCode.CSharp.Core.Extensions;
+using AndcultureCode.CSharp.Core.Interfaces;
+using AndcultureCode.CSharp.Core.Enumerations;
+
+namespace AndcultureCode.CSharp.Core.Tests.Unit.Extensions
+{
+    public class IAndcultureCodeWebHostBuilderExtensionsTest : UnitTestBase
+    {
+        #region Setup
+
+        public IAndcultureCodeWebHostBuilderExtensionsTest(ITestOutputHelper output) : base(output) {}
+
+        #endregion Setup
+
+
+        #region PreloadAmazonElasticBeanstalk
+
+        [Fact(Skip = "TODO: NFPA-84")]
+        public void PreloadAmazonElasticBeanstalk_Write_Tests()
+        {
+            true.ShouldBeFalse();
+        }
+
+        #endregion PreloadAmazonElasticBeanstalk
+    }
+}

--- a/test/AndcultureCode.CSharp.Core.Tests/Extensions/IAndcultureCodeWebHostBuilderExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Extensions/IAndcultureCodeWebHostBuilderExtensionsTest.cs
@@ -45,7 +45,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Extensions
         public void PreloadAmazonElasticBeanstalk_When_Contains_AspNetCore_Environment_Sets_Global_EnvironmentVariable()
         {
             // Arrange
-            var expected     = Random.String();
+            var expected     = $"testValue{Random.Int()}";
             var mockBuilder  = new Mock<IAndcultureCodeWebHostBuilder>();
             var mockProvider = new Mock<AmazonEBConfigurationProvider>();
             mockProvider.Setup(e => e.Has(IAndcultureCodeWebHostBuilderExtensions.ASPNETCORE_ENVIRONMENT)).Returns(true);

--- a/test/AndcultureCode.CSharp.Core.Tests/Extensions/IConfigurationBuilderExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Extensions/IConfigurationBuilderExtensionsTest.cs
@@ -9,6 +9,8 @@ using AndcultureCode.CSharp.Core.Models;
 using AndcultureCode.CSharp.Core.Extensions;
 using AndcultureCode.CSharp.Core.Interfaces;
 using AndcultureCode.CSharp.Core.Enumerations;
+using Microsoft.Extensions.Configuration;
+using Moq;
 
 namespace AndcultureCode.CSharp.Core.Tests.Unit.Extensions
 {
@@ -23,10 +25,30 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Extensions
 
         #region AddAmazonElasticBeanstalk
 
-        [Fact(Skip = "TODO: NFPA-84")]
-        public void AddAmazonElasticBeanstalk_Write_Tests()
+        [Fact]
+        public void AddAmazonElasticBeanstalk_Returns_Original_Builder()
         {
-            true.ShouldBeFalse();
+            // Arrange
+            var mockBuilder = new Mock<IConfigurationBuilder>();
+
+            // Act
+            var result = IConfigurationBuilderExtensions.AddAmazonElasticBeanstalk(mockBuilder.Object);
+
+            // Assert
+            result.ShouldBe(mockBuilder.Object);
+        }
+
+        [Fact]
+        public void AddAmazonElasticBeanstalk_Appends_New_ConfigurationSource()
+        {
+            // Arrange
+            var mockBuilder = new Mock<IConfigurationBuilder>();
+
+            // Act
+            var result = IConfigurationBuilderExtensions.AddAmazonElasticBeanstalk(mockBuilder.Object);
+
+            // Assert
+            mockBuilder.Verify(e => e.Add(It.IsAny<IConfigurationSource>()), Times.Once);
         }
 
         #endregion AddAmazonElasticBeanstalk

--- a/test/AndcultureCode.CSharp.Core.Tests/Extensions/IConfigurationBuilderExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Extensions/IConfigurationBuilderExtensionsTest.cs
@@ -1,0 +1,34 @@
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+using AndcultureCode.CSharp.Testing;
+using AndcultureCode.CSharp.Testing.Extensions;
+using AndcultureCode.CSharp.Core.Models;
+using AndcultureCode.CSharp.Core.Extensions;
+using AndcultureCode.CSharp.Core.Interfaces;
+using AndcultureCode.CSharp.Core.Enumerations;
+
+namespace AndcultureCode.CSharp.Core.Tests.Unit.Extensions
+{
+    public class IConfigurationBuilderExtensionsTest : UnitTestBase
+    {
+        #region Setup
+
+        public IConfigurationBuilderExtensionsTest(ITestOutputHelper output) : base(output) {}
+
+        #endregion Setup
+
+
+        #region AddAmazonElasticBeanstalk
+
+        [Fact(Skip = "TODO: NFPA-84")]
+        public void AddAmazonElasticBeanstalk_Write_Tests()
+        {
+            true.ShouldBeFalse();
+        }
+
+        #endregion AddAmazonElasticBeanstalk
+    }
+}

--- a/test/AndcultureCode.CSharp.Core.Tests/Models/Hosting/AndcultureCodeWebHostBuilderTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Models/Hosting/AndcultureCodeWebHostBuilderTest.cs
@@ -1,0 +1,59 @@
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+using AndcultureCode.CSharp.Testing;
+using AndcultureCode.CSharp.Testing.Extensions;
+using AndcultureCode.CSharp.Core.Models;
+using AndcultureCode.CSharp.Core.Extensions;
+using AndcultureCode.CSharp.Core.Interfaces;
+using AndcultureCode.CSharp.Core.Enumerations;
+using AndcultureCode.CSharp.Core.Models.Hosting;
+
+namespace AndcultureCode.CSharp.Core.Tests.Unit.Models.Hosting
+{
+    public class AndcultureCodeWebHostBuilderTest : UnitTestBase
+    {
+        #region Setup
+
+        public AndcultureCodeWebHostBuilderTest(ITestOutputHelper output) : base(output) {}
+
+        #endregion Setup
+
+
+        #region Constructor (string[] args)
+
+        [Fact]
+        public void Constructor_Overload_With_Args_Null_Sets_Args_Null()
+        {
+            new AndcultureCodeWebHostBuilder(args: null).Args.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Constructor_Overload_With_Args_NotNull_Sets_Args_To_Provided_Value()
+        {
+            // Arrange
+            var expected = new string[] { Random.String() };
+
+            // Act
+            var sut = new AndcultureCodeWebHostBuilder(args: expected);
+
+            // Assert
+            sut.Args.ShouldBe(expected);
+        }
+
+        #endregion Constructor (string[] args)
+
+
+        #region CreateDefaultBuilder
+
+        [Fact]
+        public void CreateDefaultBuilder_Returns_Builder()
+        {
+            new AndcultureCodeWebHostBuilder().CreateDefaultBuilder().ShouldNotBeNull();
+        }
+
+        #endregion CreateDefaultBuilder
+    }
+}

--- a/test/AndcultureCode.CSharp.Core.Tests/Utilities/Configuration/AmazonEBConfigurationProviderTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Utilities/Configuration/AmazonEBConfigurationProviderTest.cs
@@ -97,6 +97,67 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
         #endregion Has
 
 
+        #region Load
+
+        [Fact]
+        public void Load_When_Configuration_DoesNotExist_DoesNotThrow()
+        {
+            // Arrange
+            var sut = new AmazonEBConfigurationProvider(configurationFilePath: "file-that-does-not-exist");
+
+            // Act
+            var result = Record.Exception(() => sut.Load());
+
+            // Assert
+            result.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Load_When_Configuration_Exists_Without_Values_DoesNotThrow()
+        {
+            // Arrange
+            var filePath = $"test-file-{Random.Int()}";
+            File.WriteAllText(filePath, "{}");
+            var sut = new AmazonEBConfigurationProvider(configurationFilePath: filePath);
+
+            // Act
+            var result = Record.Exception(() => sut.Load());
+
+            // Assert
+            result.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Load_When_Configuration_Exists_With_Values_DoesNotThrow()
+        {
+            // Arrange
+            var filePath             = $"test-file-{Random.Int()}";
+            var testPropertyName     = "testProperty";
+            var testPropertyValue    = Random.Int().ToString();
+            var expected = new
+            {
+                iis = new
+                {
+                    env = new string []
+                    {
+                        $"{testPropertyName}={testPropertyValue}"
+                    }
+                }
+            };
+
+            File.WriteAllText(filePath, JsonConvert.SerializeObject(expected, Formatting.Indented));
+            var sut = new AmazonEBConfigurationProvider(configurationFilePath: filePath);
+
+            // Act
+            var result = Record.Exception(() => sut.Load());
+
+            // Assert
+            result.ShouldBeNull();
+        }
+
+        #endregion Load
+
+
         #region Read
 
         [Fact]

--- a/test/AndcultureCode.CSharp.Core.Tests/Utilities/Configuration/AmazonEBConfigurationProviderTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Utilities/Configuration/AmazonEBConfigurationProviderTest.cs
@@ -95,24 +95,6 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
         #endregion Has
 
 
-        #region Load
-
-        [Fact(Skip = "TODO: NFPA-84")]
-        public void Load_When_NoConfigurationData_Returns_With_Data_NotNull()
-        {
-            // // Arrange
-            // var sut = new AmazonEBConfigurationProvider();
-
-            // // Act
-            // sut.Load();
-
-            // // Assert
-            // sut.Data.ShouldNotBeNull();
-        }
-
-        #endregion Load
-
-
         #region ReadConfiguration
 
         [Fact(Skip = "TODO: NFPA-84")]

--- a/test/AndcultureCode.CSharp.Core.Tests/Utilities/Configuration/AmazonEBConfigurationProviderTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Utilities/Configuration/AmazonEBConfigurationProviderTest.cs
@@ -1,0 +1,126 @@
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+using AndcultureCode.CSharp.Testing;
+using AndcultureCode.CSharp.Testing.Extensions;
+using AndcultureCode.CSharp.Core.Models;
+using AndcultureCode.CSharp.Core.Extensions;
+using AndcultureCode.CSharp.Core.Interfaces;
+using AndcultureCode.CSharp.Core.Enumerations;
+using AndcultureCode.CSharp.Core.Utilities.Configuration;
+using Moq;
+
+namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
+{
+    public class AndcultureEBConfigurationProviderTest : UnitTestBase
+    {
+        #region Setup
+
+        public AndcultureEBConfigurationProviderTest(ITestOutputHelper output) : base(output) {}
+
+        #endregion Setup
+
+
+        #region Get
+
+        [Fact]
+        public void Get_When_Key_DoesNotExist_Returns_Null()
+        {
+            // Arrange
+            var sut = new AmazonEBConfigurationProvider();
+
+            // Act
+            var result = sut.Get("notfound");
+
+            // Assert
+            result.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Get_When_Key_DoesExist_Returns_ExpectedValue()
+        {
+            // Arrange
+            var expectedKey   = Random.String();
+            var expectedValue = Random.String();
+            var sutMock       = new Mock<AmazonEBConfigurationProvider>() { CallBase = true };
+            var sut           = sutMock.Object;
+
+            sutMock.Setup(e => e.ReadConfiguration()).Returns(new Dictionary<string, string> { { expectedKey, expectedValue }});
+
+            // Act
+            var result = sut.Get(expectedKey);
+
+            // Assert
+            result.ShouldBe(expectedValue);
+        }
+
+        #endregion Get
+
+
+        #region Has
+
+        [Fact]
+        public void Has_When_Key_DoesNotExist_Returns_False()
+        {
+            // Arrange
+            var sut = new AmazonEBConfigurationProvider();
+
+            // Act
+            var result = sut.Has("notfound");
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Has_When_Key_DoesExist_Returns_True()
+        {
+            // Arrange
+            var expectedKey   = Random.String();
+            var expectedValue = Random.String();
+            var sutMock       = new Mock<AmazonEBConfigurationProvider>() { CallBase = true };
+            var sut           = sutMock.Object;
+
+            sutMock.Setup(e => e.ReadConfiguration()).Returns(new Dictionary<string, string> { { expectedKey, expectedValue }});
+
+            // Act
+            var result = sut.Has(expectedKey);
+
+            // Assert
+            result.ShouldBeTrue();
+        }
+
+        #endregion Has
+
+
+        #region Load
+
+        [Fact(Skip = "TODO: NFPA-84")]
+        public void Load_When_NoConfigurationData_Returns_With_Data_NotNull()
+        {
+            // // Arrange
+            // var sut = new AmazonEBConfigurationProvider();
+
+            // // Act
+            // sut.Load();
+
+            // // Assert
+            // sut.Data.ShouldNotBeNull();
+        }
+
+        #endregion Load
+
+
+        #region ReadConfiguration
+
+        [Fact(Skip = "TODO: NFPA-84")]
+        public void ReadConfiguration_Write_Tests()
+        {
+            true.ShouldBeFalse();
+        }
+
+        #endregion ReadConfiguration
+    }
+}

--- a/test/AndcultureCode.CSharp.Core.Tests/Utilities/Configuration/AmazonEBConfigurationProviderTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Utilities/Configuration/AmazonEBConfigurationProviderTest.cs
@@ -49,7 +49,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
             var sutMock       = new Mock<AmazonEBConfigurationProvider>() { CallBase = true };
             var sut           = sutMock.Object;
 
-            sutMock.Setup(e => e.ReadConfiguration()).Returns(new Dictionary<string, string> { { expectedKey, expectedValue }});
+            sutMock.Setup(e => e.Read()).Returns(new Dictionary<string, string> { { expectedKey, expectedValue }});
 
             // Act
             var result = sut.Get(expectedKey);
@@ -85,7 +85,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
             var sutMock       = new Mock<AmazonEBConfigurationProvider>() { CallBase = true };
             var sut           = sutMock.Object;
 
-            sutMock.Setup(e => e.ReadConfiguration()).Returns(new Dictionary<string, string> { { expectedKey, expectedValue }});
+            sutMock.Setup(e => e.Read()).Returns(new Dictionary<string, string> { { expectedKey, expectedValue }});
 
             // Act
             var result = sut.Has(expectedKey);
@@ -97,10 +97,10 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
         #endregion Has
 
 
-        #region ReadConfiguration
+        #region Read
 
         [Fact]
-        public void ReadConfiguration_When_CachedConfiguration_Set_Returns_CachedConfiguration()
+        public void Read_When_CachedConfiguration_Set_Returns_CachedConfiguration()
         {
             // Arrange
             var expected = new Dictionary<string, string>();
@@ -108,20 +108,20 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
             sut.CachedConfiguration = expected;
 
             // Act
-            var result = sut.ReadConfiguration();
+            var result = sut.Read();
 
             // Assert
             result.ShouldBe(expected);
         }
 
         [Fact]
-        public void ReadConfiguration_When_ConfigurationFilePath_DoesNotExist_Returns_Empty_Dictionary()
+        public void Read_When_ConfigurationFilePath_DoesNotExist_Returns_Empty_Dictionary()
         {
             // Arrange
             var sut = new AmazonEBConfigurationProvider(configurationFilePath: "/file-that-does-not-exist");
 
             // Act
-            var result = sut.ReadConfiguration();
+            var result = sut.Read();
 
             // Assert
             result.ShouldNotBeNull();
@@ -129,7 +129,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
         }
 
         [Fact]
-        public void ReadConfiguration_When_ConfigurationFilePath_InvalidJson_Returns_Empty_Dictionary()
+        public void Read_When_ConfigurationFilePath_InvalidJson_Returns_Empty_Dictionary()
         {
             // Arrange
             var filePath = $"test-file-{Random.Int()}";
@@ -137,7 +137,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
             var sut = new AmazonEBConfigurationProvider(configurationFilePath: filePath);
 
             // Act
-            var result = sut.ReadConfiguration();
+            var result = sut.Read();
 
             // Assert
             File.Delete(filePath);
@@ -146,7 +146,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
         }
 
         [Fact]
-        public void ReadConfiguration_When_ConfigurationFilePath_Without_Env_Variable_Returns_Empty_Dictionary()
+        public void Read_When_ConfigurationFilePath_Without_Env_Variable_Returns_Empty_Dictionary()
         {
             // Arrange
             var filePath = $"test-file-{Random.Int()}";
@@ -154,7 +154,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
             var sut = new AmazonEBConfigurationProvider(configurationFilePath: filePath);
 
             // Act
-            var result = sut.ReadConfiguration();
+            var result = sut.Read();
 
             // Assert
             File.Delete(filePath);
@@ -163,7 +163,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
         }
 
         [Fact]
-        public void ReadConfiguration_When_ConfigurationFilePath_With_Env_Variable_Returns_Dictionary_With_Value()
+        public void Read_When_ConfigurationFilePath_With_Env_Variable_Returns_Dictionary_With_Value()
         {
             // Arrange
             var filePath             = $"test-file-{Random.Int()}";
@@ -187,7 +187,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
             var sut = new AmazonEBConfigurationProvider(configurationFilePath: filePath);
 
             // Act
-            var result = sut.ReadConfiguration();
+            var result = sut.Read();
 
             // Assert
             File.Delete(filePath);
@@ -198,7 +198,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
         }
 
         [Fact]
-        public void ReadConfiguration_When_ConfigurationFilePath_With_Env_Variable_Containing_Double_Underscores_Returns_Dictionary_With_Value_Containing_Colon()
+        public void Read_When_ConfigurationFilePath_With_Env_Variable_Containing_Double_Underscores_Returns_Dictionary_With_Value_Containing_Colon()
         {
             // Arrange
             var filePath             = $"test-file-{Random.Int()}";
@@ -222,7 +222,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
             var sut = new AmazonEBConfigurationProvider(configurationFilePath: filePath);
 
             // Act
-            var result = sut.ReadConfiguration();
+            var result = sut.Read();
 
             // Assert
             File.Delete(filePath);
@@ -232,7 +232,7 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
             result[testPropertyNameTwo.Replace("__", ":")].ShouldBe(testPropertyValueTwo);
         }
 
-        #endregion ReadConfiguration
+        #endregion Read
 
 
     }

--- a/test/AndcultureCode.CSharp.Core.Tests/Utilities/Configuration/AmazonEBConfigurationSourceTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Utilities/Configuration/AmazonEBConfigurationSourceTest.cs
@@ -1,0 +1,45 @@
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+using AndcultureCode.CSharp.Testing;
+using AndcultureCode.CSharp.Testing.Extensions;
+using AndcultureCode.CSharp.Core.Models;
+using AndcultureCode.CSharp.Core.Extensions;
+using AndcultureCode.CSharp.Core.Interfaces;
+using AndcultureCode.CSharp.Core.Enumerations;
+using AndcultureCode.CSharp.Core.Utilities.Configuration;
+using Moq;
+using Microsoft.Extensions.Configuration;
+
+namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
+{
+    public class AndcultureEBConfigurationSourceTest : UnitTestBase
+    {
+        #region Setup
+
+        public AndcultureEBConfigurationSourceTest(ITestOutputHelper output) : base(output) {}
+
+        #endregion Setup
+
+
+        #region Build
+
+        [Fact]
+        public void Build_When_Null_Returns_Provider()
+        {
+            new AmazonEBConfigurationSource().Build(builder: null).ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Build_When_NotNull_Returns_Provider()
+        {
+            new AmazonEBConfigurationSource()                             // Arrange
+                .Build(builder: new Mock<IConfigurationBuilder>().Object) // Act
+                    .ShouldNotBeNull();                                   // Assert
+        }
+
+        #endregion Build
+    }
+}

--- a/test/AndcultureCode.CSharp.Core.Tests/Utilities/Hosting/AndcultureCodeWebHostTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Utilities/Hosting/AndcultureCodeWebHostTest.cs
@@ -1,0 +1,47 @@
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+using AndcultureCode.CSharp.Testing;
+using AndcultureCode.CSharp.Testing.Extensions;
+using AndcultureCode.CSharp.Core.Models;
+using AndcultureCode.CSharp.Core.Extensions;
+using AndcultureCode.CSharp.Core.Interfaces;
+using AndcultureCode.CSharp.Core.Enumerations;
+using AndcultureCode.CSharp.Core.Utilities.Hosting;
+
+namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Configuration
+{
+    public class AndcultureCodeWebHostTest : UnitTestBase
+    {
+        #region Setup
+
+        public AndcultureCodeWebHostTest(ITestOutputHelper output) : base(output) {}
+
+        #endregion Setup
+
+
+        #region Preload
+
+        [Fact]
+        public void Preload_When_Args_Null_Returns_Builder()
+        {
+            AndcultureCodeWebHost.Preload(args: null).ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Preload_When_Args_Empty_Array_Returns_Builder()
+        {
+            AndcultureCodeWebHost.Preload(args: new string[] {}).ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Preload_When_Args_Array_Returns_Builder()
+        {
+            AndcultureCodeWebHost.Preload(args: new string[] { Random.String() }).ShouldNotBeNull();
+        }
+
+        #endregion Preload
+    }
+}


### PR DESCRIPTION
AWS Beanstalk does not have support for piping environment variables to the dotnet core application's process. This adds that support leveraging dotnet core conventional IConfigurationProvider