### PR TITLE
Feature/add lockable core features

### DIFF
--- a/src/AndcultureCode.CSharp.Core/Interfaces/Conductors/ILockingConductor.cs
+++ b/src/AndcultureCode.CSharp.Core/Interfaces/Conductors/ILockingConductor.cs
@@ -1,0 +1,50 @@
+using System;
+using AndcultureCode.CSharp.Core.Interfaces.Entity;
+
+namespace AndcultureCode.CSharp.Core.Interfaces.Conductors
+{
+     public interface ILockingConductor<T>
+        where T : class, ILockable, IEntity
+    {
+        /// <summary>
+        /// Updates the locking fields to be set, which denotes that the user locking the record should
+        /// have exclusive access to modifying it for the lock's duration. This, however, does
+        /// not prohibit the record from being modified by others. When a record is locked, the
+        /// ValidateLock method below should be used to determine if the record can be modified. This will
+        /// ensure that only the user that locked the record is actually able to modify its contents.
+        /// </summary>
+        /// <param name="id">The record id</param>
+        /// <param name="lockUntil">The time the record should be locked until</param>
+        /// <param name="lockedById">The id of the user locking the record</param>
+        /// <returns>the updated record if it is successfully locked, null otherwise</returns>
+        IResult<T> Lock(long id, DateTimeOffset lockUntil, long? lockedById = null);
+
+        /// <summary>
+        /// Updates the locking fields back to null, meaning any user will be able to acquire a lock
+        /// so they have exclusive access to editing it.
+        /// </summary>
+        /// <param name="id">The record id</param>
+        /// <param name="unlockedById">The id of the user unlocking the record</param>
+        /// <returns>the updated record if it is successfully unlocked, null otherwise</returns>
+        IResult<T> Unlock(long id, long? unlockedById = null);
+
+        /// <summary>
+        /// Updates the LockedUntil field for the record, allowing the user that locked
+        /// it to have the lock for a longer amount of time.
+        /// </summary>
+        /// <param name="id">The record id</param>
+        /// <param name="lockUntil">The time the record should be locked until</param>
+        /// <param name="updatedById">The id of the user updating the record's lock time</param>
+        /// <returns>the updated record if the lock is successfully extended, null otherwise</returns>
+        IResult<T> ExtendLock(long id, DateTimeOffset lockUntil, long? updatedById = null);
+
+        /// <summary>
+        /// Used to determine whether or not the user attempting to update the record is the
+        /// user that has the lock, AND that the lock is still valid (i.e. not expired).
+        /// </summary>
+        /// <param name="item">The item</param>
+        /// <param name="currentUserId">The current user id</param>
+        /// <returns>true if the lock is still active and is locked by the current user, false otherwise</returns>
+        IResult<bool> ValidateLock(T item, long? currentUserId = null);
+    }
+}

--- a/src/AndcultureCode.CSharp.Core/Interfaces/Conductors/ILockingConductor.cs
+++ b/src/AndcultureCode.CSharp.Core/Interfaces/Conductors/ILockingConductor.cs
@@ -7,6 +7,16 @@ namespace AndcultureCode.CSharp.Core.Interfaces.Conductors
        where T : class, ILockable, IEntity
     {
         /// <summary>
+        /// Updates the LockedUntil field for the record, allowing the user that locked
+        /// it to have the lock for a longer amount of time.
+        /// </summary>
+        /// <param name="id">The record id</param>
+        /// <param name="lockUntil">The time the record should be locked until</param>
+        /// <param name="updatedById">The id of the user updating the record's lock time</param>
+        /// <returns>the updated record if the lock is successfully extended, null otherwise</returns>
+        IResult<T> ExtendLock(long id, DateTimeOffset lockUntil, long? updatedById = null);
+
+        /// <summary>
         /// Updates the locking fields to be set, which denotes that the user locking the record should
         /// have exclusive access to modifying it for the lock's duration. This, however, does
         /// not prohibit the record from being modified by others. When a record is locked, the
@@ -27,16 +37,6 @@ namespace AndcultureCode.CSharp.Core.Interfaces.Conductors
         /// <param name="unlockedById">The id of the user unlocking the record</param>
         /// <returns>the updated record if it is successfully unlocked, null otherwise</returns>
         IResult<T> Unlock(long id, long? unlockedById = null);
-
-        /// <summary>
-        /// Updates the LockedUntil field for the record, allowing the user that locked
-        /// it to have the lock for a longer amount of time.
-        /// </summary>
-        /// <param name="id">The record id</param>
-        /// <param name="lockUntil">The time the record should be locked until</param>
-        /// <param name="updatedById">The id of the user updating the record's lock time</param>
-        /// <returns>the updated record if the lock is successfully extended, null otherwise</returns>
-        IResult<T> ExtendLock(long id, DateTimeOffset lockUntil, long? updatedById = null);
 
         /// <summary>
         /// Used to determine whether or not the user attempting to update the record is the

--- a/src/AndcultureCode.CSharp.Core/Interfaces/Conductors/ILockingConductor.cs
+++ b/src/AndcultureCode.CSharp.Core/Interfaces/Conductors/ILockingConductor.cs
@@ -3,8 +3,8 @@ using AndcultureCode.CSharp.Core.Interfaces.Entity;
 
 namespace AndcultureCode.CSharp.Core.Interfaces.Conductors
 {
-     public interface ILockingConductor<T>
-        where T : class, ILockable, IEntity
+    public interface ILockingConductor<T>
+       where T : class, ILockable, IEntity
     {
         /// <summary>
         /// Updates the locking fields to be set, which denotes that the user locking the record should

--- a/src/AndcultureCode.CSharp.Core/Interfaces/Entity/ILockable.cs
+++ b/src/AndcultureCode.CSharp.Core/Interfaces/Entity/ILockable.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace AndcultureCode.CSharp.Core.Interfaces.Entity
+{
+    public interface ILockable
+    {
+        bool            IsLocked    { get; }
+        DateTimeOffset? LockedOn    { get; set; }
+        DateTimeOffset? LockedUntil { get; set; }
+        long?           LockedById  { get; set; }
+    }
+}

--- a/src/AndcultureCode.CSharp.Core/Interfaces/Entity/ILockable.cs
+++ b/src/AndcultureCode.CSharp.Core/Interfaces/Entity/ILockable.cs
@@ -4,9 +4,9 @@ namespace AndcultureCode.CSharp.Core.Interfaces.Entity
 {
     public interface ILockable
     {
-        bool            IsLocked    { get; }
-        DateTimeOffset? LockedOn    { get; set; }
+        bool IsLocked { get; }
+        DateTimeOffset? LockedOn { get; set; }
         DateTimeOffset? LockedUntil { get; set; }
-        long?           LockedById  { get; set; }
+        long? LockedById { get; set; }
     }
 }

--- a/src/AndcultureCode.CSharp.Core/Interfaces/Entity/ILockable.cs
+++ b/src/AndcultureCode.CSharp.Core/Interfaces/Entity/ILockable.cs
@@ -5,8 +5,8 @@ namespace AndcultureCode.CSharp.Core.Interfaces.Entity
     public interface ILockable
     {
         bool IsLocked { get; }
+        long? LockedById { get; set; }
         DateTimeOffset? LockedOn { get; set; }
         DateTimeOffset? LockedUntil { get; set; }
-        long? LockedById { get; set; }
     }
 }

--- a/src/AndcultureCode.CSharp.Core/Models/Lockable.cs
+++ b/src/AndcultureCode.CSharp.Core/Models/Lockable.cs
@@ -1,0 +1,50 @@
+using System;
+using AndcultureCode.CSharp.Core.Interfaces.Entity;
+
+namespace AndcultureCode.CSharp.Core.Models
+{
+    public abstract class Lockable : Auditable, ILockable
+    {
+        #region ILockable Implementation
+
+        #region Public Members
+
+        public DateTimeOffset? LockedOn { get; set; }
+        public DateTimeOffset? LockedUntil { get; set; }
+        public long? LockedById { get; set; }
+
+        #endregion Public Members
+
+        #region Computed Members
+
+        /// <summary>
+        /// Calculated field based on if LockedUntil (when not null) is in the past or future.
+        /// </summary>
+        public bool IsLocked => DetermineIfLocked();
+
+        #endregion Computed Members
+
+        #endregion ILockable Implementation
+
+        #region Private Methods
+
+        /// <summary>
+        /// A record is considered "locked" if the LockedUntil field is not null
+        /// and is set to a time in the future
+        /// </summary>
+        /// <returns>true if LockedUntil is not null and is set to a time in the future, false otherwise</returns>
+        private bool DetermineIfLocked()
+        {
+            var currentTime = DateTimeOffset.Now;
+            if (this.LockedUntil.HasValue)
+            {
+                return this.LockedUntil.Value > currentTime;
+            }
+
+            return false;
+        }
+
+        #endregion Private Methods
+    }
+}
+}

--- a/src/AndcultureCode.CSharp.Core/Models/Lockable.cs
+++ b/src/AndcultureCode.CSharp.Core/Models/Lockable.cs
@@ -9,9 +9,9 @@ namespace AndcultureCode.CSharp.Core.Models
 
         #region Public Members
 
+        public long? LockedById { get; set; }
         public DateTimeOffset? LockedOn { get; set; }
         public DateTimeOffset? LockedUntil { get; set; }
-        public long? LockedById { get; set; }
 
         #endregion Public Members
 

--- a/src/AndcultureCode.CSharp.Core/Models/Lockable.cs
+++ b/src/AndcultureCode.CSharp.Core/Models/Lockable.cs
@@ -47,4 +47,3 @@ namespace AndcultureCode.CSharp.Core.Models
         #endregion Private Methods
     }
 }
-}

--- a/test/AndcultureCode.CSharp.Core.Tests/Models/Entities/LocakbleTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Models/Entities/LocakbleTest.cs
@@ -1,0 +1,55 @@
+using System;
+using AndcultureCode.CSharp.Core.Tests.Stubs;
+using AndcultureCode.CSharp.Testing;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AndcultureCode.CSharp.Core.Tests.Models.Entities
+{
+    public class LocakbleTest : UnitTestBase
+    {
+        #region Setup
+
+        public LocakbleTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        #endregion Setup
+
+        #region IsLocked
+
+        [Fact]
+        public void IsLocked_When_LockedUntil_IsNull_Then_Returns_False()
+        {
+            // Arrange
+            var sut = new LockableEntity();
+
+            // Act & Assert
+            sut.IsLocked.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsLocked_When_LockedUntil_IsNotNull_And_IsGreaterThan_The_CurrentTime_Then_Returns_True()
+        {
+            // Arrange
+            var sut = new LockableEntity {LockedUntil = DateTimeOffset.Now.AddMinutes(15)};
+
+            // Act & Assert
+            sut.IsLocked.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsLocked_When_LockedUntil_IsNotNull_And_IsLessThan_CurrentTime_Then_Returns_False()
+        {
+            // Arrange
+            var sut = new LockableEntity {LockedUntil = DateTimeOffset.Now.AddMinutes(-15)};
+
+            // Act & Assert
+            sut.IsLocked.ShouldBeFalse();
+        }
+
+        #endregion IsLocked
+
+    }
+}

--- a/test/AndcultureCode.CSharp.Core.Tests/Models/Entities/LocakbleTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Models/Entities/LocakbleTest.cs
@@ -50,6 +50,5 @@ namespace AndcultureCode.CSharp.Core.Tests.Models.Entities
         }
 
         #endregion IsLocked
-
     }
 }

--- a/test/AndcultureCode.CSharp.Core.Tests/Stubs/LockableEntity.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Stubs/LockableEntity.cs
@@ -1,0 +1,10 @@
+using AndcultureCode.CSharp.Core.Models;
+
+namespace AndcultureCode.CSharp.Core.Tests.Stubs
+{
+    public class LockableEntity: Lockable
+    {
+        public string Name { get; set; }
+
+    }
+}

--- a/test/AndcultureCode.CSharp.Core.Tests/Stubs/LockableEntity.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Stubs/LockableEntity.cs
@@ -5,6 +5,5 @@ namespace AndcultureCode.CSharp.Core.Tests.Stubs
     public class LockableEntity: Lockable
     {
         public string Name { get; set; }
-
     }
 }


### PR DESCRIPTION
Adding the aspect of "Locking" resources to the core library.

There is a need across projects to prevent users from modifying the same record(s) simultaneously. This provides the interfaces and the base class for the implementation of classes implementing the Lockable interface.