### PR TITLE
Add ErrorConstants file, backfill xml doc comments in remaining constants classes

### DIFF
--- a/src/AndcultureCode.CSharp.Core/AndcultureCode.CSharp.Core.md
+++ b/src/AndcultureCode.CSharp.Core/AndcultureCode.CSharp.Core.md
@@ -29,6 +29,13 @@
   - [UserId](#P-AndcultureCode-CSharp-Core-Models-Connection-UserId 'AndcultureCode.CSharp.Core.Models.Connection.UserId')
   - [ToString(delimiter)](#M-AndcultureCode-CSharp-Core-Models-Connection-ToString-System-String- 'AndcultureCode.CSharp.Core.Models.Connection.ToString(System.String)')
   - [ValidParameter(value)](#M-AndcultureCode-CSharp-Core-Models-Connection-ValidParameter-System-String- 'AndcultureCode.CSharp.Core.Models.Connection.ValidParameter(System.String)')
+- [ContentTypes](#T-AndcultureCode-CSharp-Core-Constants-ContentTypes 'AndcultureCode.CSharp.Core.Constants.ContentTypes')
+  - [CSS](#F-AndcultureCode-CSharp-Core-Constants-ContentTypes-CSS 'AndcultureCode.CSharp.Core.Constants.ContentTypes.CSS')
+  - [HTML](#F-AndcultureCode-CSharp-Core-Constants-ContentTypes-HTML 'AndcultureCode.CSharp.Core.Constants.ContentTypes.HTML')
+  - [JAVASCRIPT](#F-AndcultureCode-CSharp-Core-Constants-ContentTypes-JAVASCRIPT 'AndcultureCode.CSharp.Core.Constants.ContentTypes.JAVASCRIPT')
+  - [JSON](#F-AndcultureCode-CSharp-Core-Constants-ContentTypes-JSON 'AndcultureCode.CSharp.Core.Constants.ContentTypes.JSON')
+  - [PDF](#F-AndcultureCode-CSharp-Core-Constants-ContentTypes-PDF 'AndcultureCode.CSharp.Core.Constants.ContentTypes.PDF')
+  - [XML](#F-AndcultureCode-CSharp-Core-Constants-ContentTypes-XML 'AndcultureCode.CSharp.Core.Constants.ContentTypes.XML')
 - [CultureTranslation](#T-AndcultureCode-CSharp-Core-Models-Localization-CultureTranslation 'AndcultureCode.CSharp.Core.Models.Localization.CultureTranslation')
   - [FilePath](#P-AndcultureCode-CSharp-Core-Models-Localization-CultureTranslation-FilePath 'AndcultureCode.CSharp.Core.Models.Localization.CultureTranslation.FilePath')
   - [Key](#P-AndcultureCode-CSharp-Core-Models-Localization-CultureTranslation-Key 'AndcultureCode.CSharp.Core.Models.Localization.CultureTranslation.Key')
@@ -58,6 +65,8 @@
   - [Join(list,keyValueDelimiter,delimiter)](#M-AndcultureCode-CSharp-Core-Extensions-EnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-Collections-Generic-KeyValuePair{System-String,System-String}},System-String,System-String- 'AndcultureCode.CSharp.Core.Extensions.EnumerableExtensions.Join(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}},System.String,System.String)')
   - [Join(list,delimiter)](#M-AndcultureCode-CSharp-Core-Extensions-EnumerableExtensions-Join-System-Collections-Generic-List{System-String},System-String- 'AndcultureCode.CSharp.Core.Extensions.EnumerableExtensions.Join(System.Collections.Generic.List{System.String},System.String)')
   - [Join(pair,delimiter)](#M-AndcultureCode-CSharp-Core-Extensions-EnumerableExtensions-Join-System-Collections-Generic-KeyValuePair{System-String,System-String},System-String- 'AndcultureCode.CSharp.Core.Extensions.EnumerableExtensions.Join(System.Collections.Generic.KeyValuePair{System.String,System.String},System.String)')
+- [ErrorConstants](#T-AndcultureCode-CSharp-Core-Constants-ErrorConstants 'AndcultureCode.CSharp.Core.Constants.ErrorConstants')
+  - [ERROR_RESOURCE_NOT_FOUND_KEY](#F-AndcultureCode-CSharp-Core-Constants-ErrorConstants-ERROR_RESOURCE_NOT_FOUND_KEY 'AndcultureCode.CSharp.Core.Constants.ErrorConstants.ERROR_RESOURCE_NOT_FOUND_KEY')
 - [GuidUtils](#T-AndcultureCode-CSharp-Core-Utilities-Security-GuidUtils 'AndcultureCode.CSharp.Core.Utilities.Security.GuidUtils')
   - [IsInvalid()](#M-AndcultureCode-CSharp-Core-Utilities-Security-GuidUtils-IsInvalid-System-String- 'AndcultureCode.CSharp.Core.Utilities.Security.GuidUtils.IsInvalid(System.String)')
   - [IsValid()](#M-AndcultureCode-CSharp-Core-Utilities-Security-GuidUtils-IsValid-System-String- 'AndcultureCode.CSharp.Core.Utilities.Security.GuidUtils.IsValid(System.String)')
@@ -183,6 +192,142 @@
 - [Recurrence](#T-AndcultureCode-CSharp-Core-Enumerations-Recurrence 'AndcultureCode.CSharp.Core.Enumerations.Recurrence')
 - [RecurringOption](#T-AndcultureCode-CSharp-Core-Models-Entities-Worker-RecurringOption 'AndcultureCode.CSharp.Core.Models.Entities.Worker.RecurringOption')
 - [Rfc4646LanguageCodes](#T-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes')
+  - [AF_ZA](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AF_ZA 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AF_ZA')
+  - [AR_AE](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_AE 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_AE')
+  - [AR_BH](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_BH 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_BH')
+  - [AR_DZ](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_DZ 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_DZ')
+  - [AR_EG](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_EG 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_EG')
+  - [AR_IQ](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_IQ 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_IQ')
+  - [AR_JO](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_JO 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_JO')
+  - [AR_KW](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_KW 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_KW')
+  - [AR_LB](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_LB 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_LB')
+  - [AR_LY](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_LY 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_LY')
+  - [AR_MA](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_MA 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_MA')
+  - [AR_OM](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_OM 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_OM')
+  - [AR_QA](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_QA 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_QA')
+  - [AR_SA](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_SA 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_SA')
+  - [AR_SY](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_SY 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_SY')
+  - [AR_TN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_TN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_TN')
+  - [AR_YE](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_YE 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.AR_YE')
+  - [BE_BY](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-BE_BY 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.BE_BY')
+  - [BG_BG](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-BG_BG 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.BG_BG')
+  - [CA_ES](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-CA_ES 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.CA_ES')
+  - [CS_CZ](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-CS_CZ 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.CS_CZ')
+  - [CY_AZ_AZ](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-CY_AZ_AZ 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.CY_AZ_AZ')
+  - [CY_SR_SP](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-CY_SR_SP 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.CY_SR_SP')
+  - [CY_UZ_UZ](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-CY_UZ_UZ 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.CY_UZ_UZ')
+  - [DA_DK](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DA_DK 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.DA_DK')
+  - [DE_AT](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DE_AT 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.DE_AT')
+  - [DE_CH](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DE_CH 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.DE_CH')
+  - [DE_DE](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DE_DE 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.DE_DE')
+  - [DE_LI](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DE_LI 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.DE_LI')
+  - [DE_LU](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DE_LU 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.DE_LU')
+  - [DIV_MV](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DIV_MV 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.DIV_MV')
+  - [EL_GR](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EL_GR 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EL_GR')
+  - [EN_AU](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_AU 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EN_AU')
+  - [EN_BZ](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_BZ 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EN_BZ')
+  - [EN_CA](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_CA 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EN_CA')
+  - [EN_CB](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_CB 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EN_CB')
+  - [EN_GB](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_GB 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EN_GB')
+  - [EN_IE](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_IE 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EN_IE')
+  - [EN_JM](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_JM 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EN_JM')
+  - [EN_NZ](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_NZ 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EN_NZ')
+  - [EN_PH](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_PH 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EN_PH')
+  - [EN_TT](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_TT 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EN_TT')
+  - [EN_US](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_US 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EN_US')
+  - [EN_ZA](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_ZA 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EN_ZA')
+  - [EN_ZW](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_ZW 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EN_ZW')
+  - [ES_AR](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_AR 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_AR')
+  - [ES_BO](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_BO 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_BO')
+  - [ES_CL](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_CL 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_CL')
+  - [ES_CO](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_CO 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_CO')
+  - [ES_CR](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_CR 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_CR')
+  - [ES_DO](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_DO 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_DO')
+  - [ES_EC](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_EC 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_EC')
+  - [ES_ES](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_ES 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_ES')
+  - [ES_GT](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_GT 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_GT')
+  - [ES_HN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_HN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_HN')
+  - [ES_MX](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_MX 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_MX')
+  - [ES_NI](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_NI 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_NI')
+  - [ES_PA](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_PA 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_PA')
+  - [ES_PE](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_PE 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_PE')
+  - [ES_PR](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_PR 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_PR')
+  - [ES_PY](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_PY 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_PY')
+  - [ES_SV](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_SV 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_SV')
+  - [ES_UY](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_UY 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_UY')
+  - [ES_VE](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_VE 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ES_VE')
+  - [ET_EE](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ET_EE 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ET_EE')
+  - [EU_ES](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EU_ES 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.EU_ES')
+  - [FA_IR](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FA_IR 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.FA_IR')
+  - [FI_FI](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FI_FI 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.FI_FI')
+  - [FO_FO](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FO_FO 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.FO_FO')
+  - [FR_BE](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FR_BE 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.FR_BE')
+  - [FR_CA](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FR_CA 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.FR_CA')
+  - [FR_CH](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FR_CH 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.FR_CH')
+  - [FR_FR](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FR_FR 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.FR_FR')
+  - [FR_LU](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FR_LU 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.FR_LU')
+  - [FR_MC](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FR_MC 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.FR_MC')
+  - [GL_ES](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-GL_ES 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.GL_ES')
+  - [GU_IN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-GU_IN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.GU_IN')
+  - [HE_IL](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-HE_IL 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.HE_IL')
+  - [HI_IN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-HI_IN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.HI_IN')
+  - [HR_HR](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-HR_HR 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.HR_HR')
+  - [HU_HU](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-HU_HU 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.HU_HU')
+  - [HY_AM](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-HY_AM 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.HY_AM')
+  - [ID_ID](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ID_ID 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ID_ID')
+  - [IS_IS](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-IS_IS 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.IS_IS')
+  - [IT_CH](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-IT_CH 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.IT_CH')
+  - [IT_IT](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-IT_IT 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.IT_IT')
+  - [JA_JP](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-JA_JP 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.JA_JP')
+  - [KA_GE](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-KA_GE 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.KA_GE')
+  - [KK_KZ](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-KK_KZ 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.KK_KZ')
+  - [KN_IN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-KN_IN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.KN_IN')
+  - [KOK_IN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-KOK_IN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.KOK_IN')
+  - [KO_KR](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-KO_KR 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.KO_KR')
+  - [KY_KZ](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-KY_KZ 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.KY_KZ')
+  - [LT_AZ_AZ](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-LT_AZ_AZ 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.LT_AZ_AZ')
+  - [LT_LT](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-LT_LT 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.LT_LT')
+  - [LT_SR_SP](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-LT_SR_SP 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.LT_SR_SP')
+  - [LT_UZ_UZ](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-LT_UZ_UZ 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.LT_UZ_UZ')
+  - [LV_LV](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-LV_LV 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.LV_LV')
+  - [MK_MK](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-MK_MK 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.MK_MK')
+  - [MN_MN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-MN_MN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.MN_MN')
+  - [MR_IN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-MR_IN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.MR_IN')
+  - [MS_BN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-MS_BN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.MS_BN')
+  - [MS_MY](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-MS_MY 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.MS_MY')
+  - [NB_NO](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-NB_NO 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.NB_NO')
+  - [NL_BE](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-NL_BE 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.NL_BE')
+  - [NL_NL](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-NL_NL 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.NL_NL')
+  - [NN_NO](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-NN_NO 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.NN_NO')
+  - [PA_IN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-PA_IN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.PA_IN')
+  - [PL_PL](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-PL_PL 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.PL_PL')
+  - [PT_BR](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-PT_BR 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.PT_BR')
+  - [PT_PT](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-PT_PT 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.PT_PT')
+  - [RO_RO](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-RO_RO 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.RO_RO')
+  - [RU_RU](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-RU_RU 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.RU_RU')
+  - [SA_IN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SA_IN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.SA_IN')
+  - [SK_SK](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SK_SK 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.SK_SK')
+  - [SL_SI](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SL_SI 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.SL_SI')
+  - [SQ_AL](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SQ_AL 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.SQ_AL')
+  - [SV_FI](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SV_FI 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.SV_FI')
+  - [SV_SE](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SV_SE 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.SV_SE')
+  - [SW_KE](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SW_KE 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.SW_KE')
+  - [SYR_SY](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SYR_SY 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.SYR_SY')
+  - [TA_IN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-TA_IN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.TA_IN')
+  - [TE_IN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-TE_IN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.TE_IN')
+  - [TH_TH](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-TH_TH 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.TH_TH')
+  - [TR_TR](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-TR_TR 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.TR_TR')
+  - [TT_RU](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-TT_RU 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.TT_RU')
+  - [UK_UA](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-UK_UA 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.UK_UA')
+  - [UR_PK](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-UR_PK 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.UR_PK')
+  - [VI_VN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-VI_VN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.VI_VN')
+  - [ZH_CHS](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_CHS 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ZH_CHS')
+  - [ZH_CHT](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_CHT 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ZH_CHT')
+  - [ZH_CN](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_CN 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ZH_CN')
+  - [ZH_HK](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_HK 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ZH_HK')
+  - [ZH_MO](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_MO 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ZH_MO')
+  - [ZH_SG](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_SG 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ZH_SG')
+  - [ZH_TW](#F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_TW 'AndcultureCode.CSharp.Core.Constants.Rfc4646LanguageCodes.ZH_TW')
 - [StringExtensions](#T-AndcultureCode-CSharp-Core-Extensions-StringExtensions 'AndcultureCode.CSharp.Core.Extensions.StringExtensions')
   - [LoadTranslations()](#M-AndcultureCode-CSharp-Core-Extensions-StringExtensions-LoadTranslations-System-String,System-String,Newtonsoft-Json-JsonSerializerSettings- 'AndcultureCode.CSharp.Core.Extensions.StringExtensions.LoadTranslations(System.String,System.String,Newtonsoft.Json.JsonSerializerSettings)')
 - [UriUtils](#T-AndcultureCode-CSharp-Core-Utilities-Network-UriUtils 'AndcultureCode.CSharp.Core.Utilities.Network.UriUtils')
@@ -459,6 +604,61 @@ Determines if the supplied value is a valid param
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | value | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+
+<a name='T-AndcultureCode-CSharp-Core-Constants-ContentTypes'></a>
+## ContentTypes `type`
+
+##### Namespace
+
+AndcultureCode.CSharp.Core.Constants
+
+##### Summary
+
+Constants class to hold the various 'Content-Type' headers which indicate the media type
+of the resource.
+See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-ContentTypes-CSS'></a>
+### CSS `constants`
+
+##### Summary
+
+Cascading Style Sheets (CSS)
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-ContentTypes-HTML'></a>
+### HTML `constants`
+
+##### Summary
+
+HyperText Markup Language (HTML)
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-ContentTypes-JAVASCRIPT'></a>
+### JAVASCRIPT `constants`
+
+##### Summary
+
+JavaScript
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-ContentTypes-JSON'></a>
+### JSON `constants`
+
+##### Summary
+
+JavaScript Object Notation (JSON)
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-ContentTypes-PDF'></a>
+### PDF `constants`
+
+##### Summary
+
+Adobe Portable Document Format (PDF)
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-ContentTypes-XML'></a>
+### XML `constants`
+
+##### Summary
+
+Extensible Markup Language (XML)
 
 <a name='T-AndcultureCode-CSharp-Core-Models-Localization-CultureTranslation'></a>
 ## CultureTranslation `type`
@@ -804,6 +1004,24 @@ Convenience method so joining key value pairs
 | ---- | ---- | ----------- |
 | pair | [System.Collections.Generic.KeyValuePair{System.String,System.String}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.KeyValuePair 'System.Collections.Generic.KeyValuePair{System.String,System.String}') |  |
 | delimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+
+<a name='T-AndcultureCode-CSharp-Core-Constants-ErrorConstants'></a>
+## ErrorConstants `type`
+
+##### Namespace
+
+AndcultureCode.CSharp.Core.Constants
+
+##### Summary
+
+Constants class to hold generic error keys and messages.
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-ErrorConstants-ERROR_RESOURCE_NOT_FOUND_KEY'></a>
+### ERROR_RESOURCE_NOT_FOUND_KEY `constants`
+
+##### Summary
+
+Error key for when a resource/object cannot be located (soft-deleted, does not exist, etc.)
 
 <a name='T-AndcultureCode-CSharp-Core-Utilities-Security-GuidUtils'></a>
 ## GuidUtils `type`
@@ -2382,6 +2600,10 @@ Name of the provider
 
 AndcultureCode.CSharp.Core.Constants
 
+##### Summary
+
+Constants class to hold identifiers for a queue concept
+
 <a name='F-AndcultureCode-CSharp-Core-Constants-Queue-ALL'></a>
 ### ALL `constants`
 
@@ -2430,6 +2652,958 @@ AndcultureCode.CSharp.Core.Constants
 
 RFC-4646 Language Codes
 See https://docs.microsoft.com/en-us/previous-versions/commerce-server/ee825488(v=cs.20)?redirectedfrom=MSDN
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AF_ZA'></a>
+### AF_ZA `constants`
+
+##### Summary
+
+Afrikaans - South Africa
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_AE'></a>
+### AR_AE `constants`
+
+##### Summary
+
+Arabic - United Arab Emirates
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_BH'></a>
+### AR_BH `constants`
+
+##### Summary
+
+Arabic - Bahrain
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_DZ'></a>
+### AR_DZ `constants`
+
+##### Summary
+
+Arabic - Algeria
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_EG'></a>
+### AR_EG `constants`
+
+##### Summary
+
+Arabic - Egypt
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_IQ'></a>
+### AR_IQ `constants`
+
+##### Summary
+
+Arabic - Iraq
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_JO'></a>
+### AR_JO `constants`
+
+##### Summary
+
+Arabic - Jordan
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_KW'></a>
+### AR_KW `constants`
+
+##### Summary
+
+Arabic - Kuwait
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_LB'></a>
+### AR_LB `constants`
+
+##### Summary
+
+Arabic - Lebanon
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_LY'></a>
+### AR_LY `constants`
+
+##### Summary
+
+Arabic - Libya
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_MA'></a>
+### AR_MA `constants`
+
+##### Summary
+
+Arabic - Morocco
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_OM'></a>
+### AR_OM `constants`
+
+##### Summary
+
+Arabic - Oman
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_QA'></a>
+### AR_QA `constants`
+
+##### Summary
+
+Arabic - Qatar
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_SA'></a>
+### AR_SA `constants`
+
+##### Summary
+
+Arabic - Saudi Arabia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_SY'></a>
+### AR_SY `constants`
+
+##### Summary
+
+Arabic - Syria
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_TN'></a>
+### AR_TN `constants`
+
+##### Summary
+
+Arabic - Tunisia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-AR_YE'></a>
+### AR_YE `constants`
+
+##### Summary
+
+Arabic - Yemen
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-BE_BY'></a>
+### BE_BY `constants`
+
+##### Summary
+
+Belarusian - Belarus
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-BG_BG'></a>
+### BG_BG `constants`
+
+##### Summary
+
+Bulgarian - Bulgaria
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-CA_ES'></a>
+### CA_ES `constants`
+
+##### Summary
+
+Catalan - Catalan
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-CS_CZ'></a>
+### CS_CZ `constants`
+
+##### Summary
+
+Czech - Czech Republic
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-CY_AZ_AZ'></a>
+### CY_AZ_AZ `constants`
+
+##### Summary
+
+Azeri (Cyrillic) - Azerbaijan
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-CY_SR_SP'></a>
+### CY_SR_SP `constants`
+
+##### Summary
+
+Serbian (Cyrillic) - Serbia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-CY_UZ_UZ'></a>
+### CY_UZ_UZ `constants`
+
+##### Summary
+
+Uzbek (Cyrillic) - Uzbekistan
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DA_DK'></a>
+### DA_DK `constants`
+
+##### Summary
+
+Danish - Denmark
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DE_AT'></a>
+### DE_AT `constants`
+
+##### Summary
+
+German - Austria
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DE_CH'></a>
+### DE_CH `constants`
+
+##### Summary
+
+German - Switzerland
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DE_DE'></a>
+### DE_DE `constants`
+
+##### Summary
+
+German - Germany
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DE_LI'></a>
+### DE_LI `constants`
+
+##### Summary
+
+German - Liechtenstein
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DE_LU'></a>
+### DE_LU `constants`
+
+##### Summary
+
+German - Luxembourg
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-DIV_MV'></a>
+### DIV_MV `constants`
+
+##### Summary
+
+Dhivehi - Maldives
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EL_GR'></a>
+### EL_GR `constants`
+
+##### Summary
+
+Greek - Greece
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_AU'></a>
+### EN_AU `constants`
+
+##### Summary
+
+English - Australia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_BZ'></a>
+### EN_BZ `constants`
+
+##### Summary
+
+English - Belize
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_CA'></a>
+### EN_CA `constants`
+
+##### Summary
+
+English - Canada
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_CB'></a>
+### EN_CB `constants`
+
+##### Summary
+
+English - Caribbean
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_GB'></a>
+### EN_GB `constants`
+
+##### Summary
+
+English - United Kingdom
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_IE'></a>
+### EN_IE `constants`
+
+##### Summary
+
+English - Ireland
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_JM'></a>
+### EN_JM `constants`
+
+##### Summary
+
+English - Jamaica
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_NZ'></a>
+### EN_NZ `constants`
+
+##### Summary
+
+English - New Zealand
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_PH'></a>
+### EN_PH `constants`
+
+##### Summary
+
+English - Philippines
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_TT'></a>
+### EN_TT `constants`
+
+##### Summary
+
+English - Trinidad and Tobago
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_US'></a>
+### EN_US `constants`
+
+##### Summary
+
+English - United States
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_ZA'></a>
+### EN_ZA `constants`
+
+##### Summary
+
+English - South Africa
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EN_ZW'></a>
+### EN_ZW `constants`
+
+##### Summary
+
+English - Zimbabwe
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_AR'></a>
+### ES_AR `constants`
+
+##### Summary
+
+Spanish - Argentina
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_BO'></a>
+### ES_BO `constants`
+
+##### Summary
+
+Spanish - Bolivia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_CL'></a>
+### ES_CL `constants`
+
+##### Summary
+
+Spanish - Chile
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_CO'></a>
+### ES_CO `constants`
+
+##### Summary
+
+Spanish - Colombia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_CR'></a>
+### ES_CR `constants`
+
+##### Summary
+
+Spanish - Costa Rica
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_DO'></a>
+### ES_DO `constants`
+
+##### Summary
+
+Spanish - Dominican Republic
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_EC'></a>
+### ES_EC `constants`
+
+##### Summary
+
+Spanish - Ecuador
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_ES'></a>
+### ES_ES `constants`
+
+##### Summary
+
+Spanish - Spain
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_GT'></a>
+### ES_GT `constants`
+
+##### Summary
+
+Spanish - Guatemala
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_HN'></a>
+### ES_HN `constants`
+
+##### Summary
+
+Spanish - Honduras
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_MX'></a>
+### ES_MX `constants`
+
+##### Summary
+
+Spanish - Mexico
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_NI'></a>
+### ES_NI `constants`
+
+##### Summary
+
+Spanish - Nicaragua
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_PA'></a>
+### ES_PA `constants`
+
+##### Summary
+
+Spanish - Panama
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_PE'></a>
+### ES_PE `constants`
+
+##### Summary
+
+Spanish - Peru
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_PR'></a>
+### ES_PR `constants`
+
+##### Summary
+
+Spanish - Puerto Rico
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_PY'></a>
+### ES_PY `constants`
+
+##### Summary
+
+Spanish - Paraguay
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_SV'></a>
+### ES_SV `constants`
+
+##### Summary
+
+Spanish - El Salvador
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_UY'></a>
+### ES_UY `constants`
+
+##### Summary
+
+Spanish - Uruguay
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ES_VE'></a>
+### ES_VE `constants`
+
+##### Summary
+
+Spanish - Venezuela
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ET_EE'></a>
+### ET_EE `constants`
+
+##### Summary
+
+Estonian - Estonia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-EU_ES'></a>
+### EU_ES `constants`
+
+##### Summary
+
+Basque - Basque
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FA_IR'></a>
+### FA_IR `constants`
+
+##### Summary
+
+Farsi - Iran
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FI_FI'></a>
+### FI_FI `constants`
+
+##### Summary
+
+Finnish - Finland
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FO_FO'></a>
+### FO_FO `constants`
+
+##### Summary
+
+Faroese - Faroe Islands
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FR_BE'></a>
+### FR_BE `constants`
+
+##### Summary
+
+French - Belgium
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FR_CA'></a>
+### FR_CA `constants`
+
+##### Summary
+
+French - Canada
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FR_CH'></a>
+### FR_CH `constants`
+
+##### Summary
+
+French - Switzerland
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FR_FR'></a>
+### FR_FR `constants`
+
+##### Summary
+
+French - France
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FR_LU'></a>
+### FR_LU `constants`
+
+##### Summary
+
+French - Luxembourg
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-FR_MC'></a>
+### FR_MC `constants`
+
+##### Summary
+
+French - Monaco
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-GL_ES'></a>
+### GL_ES `constants`
+
+##### Summary
+
+Galician - Galician
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-GU_IN'></a>
+### GU_IN `constants`
+
+##### Summary
+
+Gujarati - India
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-HE_IL'></a>
+### HE_IL `constants`
+
+##### Summary
+
+Hebrew - Israel
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-HI_IN'></a>
+### HI_IN `constants`
+
+##### Summary
+
+Hindi - India
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-HR_HR'></a>
+### HR_HR `constants`
+
+##### Summary
+
+Croatian - Croatia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-HU_HU'></a>
+### HU_HU `constants`
+
+##### Summary
+
+Hungarian - Hungary
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-HY_AM'></a>
+### HY_AM `constants`
+
+##### Summary
+
+Armenian - Armenia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ID_ID'></a>
+### ID_ID `constants`
+
+##### Summary
+
+Indonesian - Indonesia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-IS_IS'></a>
+### IS_IS `constants`
+
+##### Summary
+
+Icelandic - Iceland
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-IT_CH'></a>
+### IT_CH `constants`
+
+##### Summary
+
+Italian - Switzerland
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-IT_IT'></a>
+### IT_IT `constants`
+
+##### Summary
+
+Italian - Italy
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-JA_JP'></a>
+### JA_JP `constants`
+
+##### Summary
+
+Japanese - Japan
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-KA_GE'></a>
+### KA_GE `constants`
+
+##### Summary
+
+Georgian - Georgia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-KK_KZ'></a>
+### KK_KZ `constants`
+
+##### Summary
+
+Kazakh - Kazakhstan
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-KN_IN'></a>
+### KN_IN `constants`
+
+##### Summary
+
+Kannada - India
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-KOK_IN'></a>
+### KOK_IN `constants`
+
+##### Summary
+
+Konkani - India
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-KO_KR'></a>
+### KO_KR `constants`
+
+##### Summary
+
+Korean - Korea
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-KY_KZ'></a>
+### KY_KZ `constants`
+
+##### Summary
+
+Kyrgyz - Kazakhstan
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-LT_AZ_AZ'></a>
+### LT_AZ_AZ `constants`
+
+##### Summary
+
+Azeri (Latin) - Azerbaijan
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-LT_LT'></a>
+### LT_LT `constants`
+
+##### Summary
+
+Lithuanian - Lithuania
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-LT_SR_SP'></a>
+### LT_SR_SP `constants`
+
+##### Summary
+
+Serbian (Latin) - Serbia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-LT_UZ_UZ'></a>
+### LT_UZ_UZ `constants`
+
+##### Summary
+
+Uzbek (Latin) - Uzbekistan
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-LV_LV'></a>
+### LV_LV `constants`
+
+##### Summary
+
+Latvian - Latvia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-MK_MK'></a>
+### MK_MK `constants`
+
+##### Summary
+
+Macedonian (FYROM)
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-MN_MN'></a>
+### MN_MN `constants`
+
+##### Summary
+
+Mongolian - Mongolia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-MR_IN'></a>
+### MR_IN `constants`
+
+##### Summary
+
+Marathi - India
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-MS_BN'></a>
+### MS_BN `constants`
+
+##### Summary
+
+Malay - Brunei
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-MS_MY'></a>
+### MS_MY `constants`
+
+##### Summary
+
+Malay - Malaysia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-NB_NO'></a>
+### NB_NO `constants`
+
+##### Summary
+
+Norwegian (Bokmål) - Norway
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-NL_BE'></a>
+### NL_BE `constants`
+
+##### Summary
+
+Dutch - Belgium
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-NL_NL'></a>
+### NL_NL `constants`
+
+##### Summary
+
+Dutch - The Netherlands
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-NN_NO'></a>
+### NN_NO `constants`
+
+##### Summary
+
+Norwegian (Nynorsk) - Norway
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-PA_IN'></a>
+### PA_IN `constants`
+
+##### Summary
+
+Punjabi - India
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-PL_PL'></a>
+### PL_PL `constants`
+
+##### Summary
+
+Polish - Poland
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-PT_BR'></a>
+### PT_BR `constants`
+
+##### Summary
+
+Portuguese - Brazil
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-PT_PT'></a>
+### PT_PT `constants`
+
+##### Summary
+
+Portuguese - Portugal
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-RO_RO'></a>
+### RO_RO `constants`
+
+##### Summary
+
+Romanian - Romania
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-RU_RU'></a>
+### RU_RU `constants`
+
+##### Summary
+
+Russian - Russia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SA_IN'></a>
+### SA_IN `constants`
+
+##### Summary
+
+Sanskrit - India
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SK_SK'></a>
+### SK_SK `constants`
+
+##### Summary
+
+Slovak - Slovakia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SL_SI'></a>
+### SL_SI `constants`
+
+##### Summary
+
+Slovenian - Slovenia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SQ_AL'></a>
+### SQ_AL `constants`
+
+##### Summary
+
+Albanian - Albania
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SV_FI'></a>
+### SV_FI `constants`
+
+##### Summary
+
+Swedish - Finland
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SV_SE'></a>
+### SV_SE `constants`
+
+##### Summary
+
+Swedish - Sweden
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SW_KE'></a>
+### SW_KE `constants`
+
+##### Summary
+
+Swahili - Kenya
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-SYR_SY'></a>
+### SYR_SY `constants`
+
+##### Summary
+
+Syriac - Syria
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-TA_IN'></a>
+### TA_IN `constants`
+
+##### Summary
+
+Tamil - India
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-TE_IN'></a>
+### TE_IN `constants`
+
+##### Summary
+
+Telugu - India
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-TH_TH'></a>
+### TH_TH `constants`
+
+##### Summary
+
+Thai - Thailand
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-TR_TR'></a>
+### TR_TR `constants`
+
+##### Summary
+
+Turkish - Turkey
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-TT_RU'></a>
+### TT_RU `constants`
+
+##### Summary
+
+Tatar - Russia
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-UK_UA'></a>
+### UK_UA `constants`
+
+##### Summary
+
+Ukrainian - Ukraine
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-UR_PK'></a>
+### UR_PK `constants`
+
+##### Summary
+
+Urdu - Pakistan
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-VI_VN'></a>
+### VI_VN `constants`
+
+##### Summary
+
+Vietnamese - Vietnam
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_CHS'></a>
+### ZH_CHS `constants`
+
+##### Summary
+
+Chinese (Simplified)
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_CHT'></a>
+### ZH_CHT `constants`
+
+##### Summary
+
+Chinese (Traditional)
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_CN'></a>
+### ZH_CN `constants`
+
+##### Summary
+
+Chinese - China
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_HK'></a>
+### ZH_HK `constants`
+
+##### Summary
+
+Chinese - Hong Kong SAR
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_MO'></a>
+### ZH_MO `constants`
+
+##### Summary
+
+Chinese - Macau SAR
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_SG'></a>
+### ZH_SG `constants`
+
+##### Summary
+
+Chinese - Singapore
+
+<a name='F-AndcultureCode-CSharp-Core-Constants-Rfc4646LanguageCodes-ZH_TW'></a>
+### ZH_TW `constants`
+
+##### Summary
+
+Chinese - Taiwan
 
 <a name='T-AndcultureCode-CSharp-Core-Extensions-StringExtensions'></a>
 ## StringExtensions `type`

--- a/src/AndcultureCode.CSharp.Core/Constants/ContentTypes.cs
+++ b/src/AndcultureCode.CSharp.Core/Constants/ContentTypes.cs
@@ -1,12 +1,40 @@
 namespace AndcultureCode.CSharp.Core.Constants
 {
+    /// <summary>
+    /// Constants class to hold the various 'Content-Type' headers which indicate the media type
+    /// of the resource.
+    /// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
+    /// </summary>
     public static class ContentTypes
     {
+        /// <summary>
+        /// Cascading Style Sheets (CSS)
+        /// </summary>
         public const string CSS = "text/css";
+
+        /// <summary>
+        /// HyperText Markup Language (HTML)
+        /// </summary>
         public const string HTML = "text/html";
+
+        /// <summary>
+        /// JavaScript
+        /// </summary>
         public const string JAVASCRIPT = "text/javascript";
+
+        /// <summary>
+        /// JavaScript Object Notation (JSON)
+        /// </summary>
         public const string JSON = "application/json";
+
+        /// <summary>
+        /// Adobe Portable Document Format (PDF)
+        /// </summary>
         public const string PDF = "application/pdf";
+
+        /// <summary>
+        /// Extensible Markup Language (XML)
+        /// </summary>
         public const string XML = "application/xml";
     }
 }

--- a/src/AndcultureCode.CSharp.Core/Constants/ErrorConstants.cs
+++ b/src/AndcultureCode.CSharp.Core/Constants/ErrorConstants.cs
@@ -1,0 +1,13 @@
+namespace AndcultureCode.CSharp.Core.Constants
+{
+    /// <summary>
+    /// Constants class to hold generic error keys and messages.
+    /// </summary>
+    public static class ErrorConstants
+    {
+        /// <summary>
+        /// Error key for when a resource/object cannot be located (soft-deleted, does not exist, etc.)
+        /// </summary>
+        public const string ERROR_RESOURCE_NOT_FOUND_KEY = "ERROR_RESOURCE_NOT_FOUND";
+    }
+}

--- a/src/AndcultureCode.CSharp.Core/Constants/Queue.cs
+++ b/src/AndcultureCode.CSharp.Core/Constants/Queue.cs
@@ -1,5 +1,8 @@
 namespace AndcultureCode.CSharp.Core.Constants
 {
+    /// <summary>
+    /// Constants class to hold identifiers for a queue concept
+    /// </summary>
     public class Queue
     {
         /// <summary>

--- a/src/AndcultureCode.CSharp.Core/Constants/Rfc4646LanguageCodes.cs
+++ b/src/AndcultureCode.CSharp.Core/Constants/Rfc4646LanguageCodes.cs
@@ -6,141 +6,684 @@ namespace AndcultureCode.CSharp.Core.Constants
     /// </summary>
     public static class Rfc4646LanguageCodes
     {
-        public const string AF_ZA = "af-ZA"; // Afrikaans - South Africa
-        public const string SQ_AL = "sq-AL"; // Albanian - Albania
-        public const string AR_DZ = "ar-DZ"; // Arabic - Algeria
-        public const string AR_BH = "ar-BH"; // Arabic - Bahrain
-        public const string AR_EG = "ar-EG"; // Arabic - Egypt
-        public const string AR_IQ = "ar-IQ"; // Arabic - Iraq
-        public const string AR_JO = "ar-JO"; // Arabic - Jordan
-        public const string AR_KW = "ar-KW"; // Arabic - Kuwait
-        public const string AR_LB = "ar-LB"; // Arabic - Lebanon
-        public const string AR_LY = "ar-LY"; // Arabic - Libya
-        public const string AR_MA = "ar-MA"; // Arabic - Morocco
-        public const string AR_OM = "ar-OM"; // Arabic - Oman
-        public const string AR_QA = "ar-QA"; // Arabic - Qatar
-        public const string AR_SA = "ar-SA"; // Arabic - Saudi Arabia
-        public const string AR_SY = "ar-SY"; // Arabic - Syria
-        public const string AR_TN = "ar-TN"; // Arabic - Tunisia
-        public const string AR_AE = "ar-AE"; // Arabic - United Arab Emirates
-        public const string AR_YE = "ar-YE"; // Arabic - Yemen
-        public const string HY_AM = "hy-AM"; // Armenian - Armenia
-        public const string CY_AZ_AZ = "Cy-az-AZ"; // Azeri (Cyrillic) - Azerbaijan
-        public const string LT_AZ_AZ = "Lt-az-AZ"; // Azeri (Latin) - Azerbaijan
-        public const string EU_ES = "eu-ES"; // Basque - Basque
-        public const string BE_BY = "be-BY"; // Belarusian - Belarus
-        public const string BG_BG = "bg-BG"; // Bulgarian - Bulgaria
-        public const string CA_ES = "ca-ES"; // Catalan - Catalan
-        public const string ZH_CN = "zh-CN"; // Chinese - China
-        public const string ZH_HK = "zh-HK"; // Chinese - Hong Kong SAR
-        public const string ZH_MO = "zh-MO"; // Chinese - Macau SAR
-        public const string ZH_SG = "zh-SG"; // Chinese - Singapore
-        public const string ZH_TW = "zh-TW"; // Chinese - Taiwan
-        public const string ZH_CHS = "zh-CHS"; // Chinese (Simplified)
-        public const string ZH_CHT = "zh-CHT"; // Chinese (Traditional)
-        public const string HR_HR = "hr-HR"; // Croatian - Croatia
-        public const string CS_CZ = "cs-CZ"; // Czech - Czech Republic
-        public const string DA_DK = "da-DK"; // Danish - Denmark
-        public const string DIV_MV = "div-MV"; // Dhivehi - Maldives
-        public const string NL_BE = "nl-BE"; // Dutch - Belgium
-        public const string NL_NL = "nl-NL"; // Dutch - The Netherlands
-        public const string EN_AU = "en-AU"; // English - Australia
-        public const string EN_BZ = "en-BZ"; // English - Belize
-        public const string EN_CA = "en-CA"; // English - Canada
-        public const string EN_CB = "en-CB"; // English - Caribbean
-        public const string EN_IE = "en-IE"; // English - Ireland
-        public const string EN_JM = "en-JM"; // English - Jamaica
-        public const string EN_NZ = "en-NZ"; // English - New Zealand
-        public const string EN_PH = "en-PH"; // English - Philippines
-        public const string EN_ZA = "en-ZA"; // English - South Africa
-        public const string EN_TT = "en-TT"; // English - Trinidad and Tobago
-        public const string EN_GB = "en-GB"; // English - United Kingdom
-        public const string EN_US = "en-US"; // English - United States
-        public const string EN_ZW = "en-ZW"; // English - Zimbabwe
-        public const string ET_EE = "et-EE"; // Estonian - Estonia
-        public const string FO_FO = "fo-FO"; // Faroese - Faroe Islands
-        public const string FA_IR = "fa-IR"; // Farsi - Iran
-        public const string FI_FI = "fi-FI"; // Finnish - Finland
-        public const string FR_BE = "fr-BE"; // French - Belgium
-        public const string FR_CA = "fr-CA"; // French - Canada
-        public const string FR_FR = "fr-FR"; // French - France
-        public const string FR_LU = "fr-LU"; // French - Luxembourg
-        public const string FR_MC = "fr-MC"; // French - Monaco
-        public const string FR_CH = "fr-CH"; // French - Switzerland
-        public const string GL_ES = "gl-ES"; // Galician - Galician
-        public const string KA_GE = "ka-GE"; // Georgian - Georgia
-        public const string DE_AT = "de-AT"; // German - Austria
-        public const string DE_DE = "de-DE"; // German - Germany
-        public const string DE_LI = "de-LI"; // German - Liechtenstein
-        public const string DE_LU = "de-LU"; // German - Luxembourg
-        public const string DE_CH = "de-CH"; // German - Switzerland
-        public const string EL_GR = "el-GR"; // Greek - Greece
-        public const string GU_IN = "gu-IN"; // Gujarati - India
-        public const string HE_IL = "he-IL"; // Hebrew - Israel
-        public const string HI_IN = "hi-IN"; // Hindi - India
-        public const string HU_HU = "hu-HU"; // Hungarian - Hungary
-        public const string IS_IS = "is-IS"; // Icelandic - Iceland
-        public const string ID_ID = "id-ID"; // Indonesian - Indonesia
-        public const string IT_IT = "it-IT"; // Italian - Italy
-        public const string IT_CH = "it-CH"; // Italian - Switzerland
-        public const string JA_JP = "ja-JP"; // Japanese - Japan
-        public const string KN_IN = "kn-IN"; // Kannada - India
-        public const string KK_KZ = "kk-KZ"; // Kazakh - Kazakhstan
-        public const string KOK_IN = "kok-IN"; // Konkani - India
-        public const string KO_KR = "ko-KR"; // Korean - Korea
-        public const string KY_KZ = "ky-KZ"; // Kyrgyz - Kazakhstan
-        public const string LV_LV = "lv-LV"; // Latvian - Latvia
-        public const string LT_LT = "lt-LT"; // Lithuanian - Lithuania
-        public const string MK_MK = "mk-MK"; // Macedonian (FYROM)
-        public const string MS_BN = "ms-BN"; // Malay - Brunei
-        public const string MS_MY = "ms-MY"; // Malay - Malaysia
-        public const string MR_IN = "mr-IN"; // Marathi - India
-        public const string MN_MN = "mn-MN"; // Mongolian - Mongolia
-        public const string NB_NO = "nb-NO"; // Norwegian (Bokmål) - Norway
-        public const string NN_NO = "nn-NO"; // Norwegian (Nynorsk) - Norway
-        public const string PL_PL = "pl-PL"; // Polish - Poland
-        public const string PT_BR = "pt-BR"; // Portuguese - Brazil
-        public const string PT_PT = "pt-PT"; // Portuguese - Portugal
-        public const string PA_IN = "pa-IN"; // Punjabi - India
-        public const string RO_RO = "ro-RO"; // Romanian - Romania
-        public const string RU_RU = "ru-RU"; // Russian - Russia
-        public const string SA_IN = "sa-IN"; // Sanskrit - India
-        public const string CY_SR_SP = "Cy-sr-SP"; // Serbian (Cyrillic) - Serbia
-        public const string LT_SR_SP = "Lt-sr-SP"; // Serbian (Latin) - Serbia
-        public const string SK_SK = "sk-SK"; // Slovak - Slovakia
-        public const string SL_SI = "sl-SI"; // Slovenian - Slovenia
-        public const string ES_AR = "es-AR"; // Spanish - Argentina
-        public const string ES_BO = "es-BO"; // Spanish - Bolivia
-        public const string ES_CL = "es-CL"; // Spanish - Chile
-        public const string ES_CO = "es-CO"; // Spanish - Colombia
-        public const string ES_CR = "es-CR"; // Spanish - Costa Rica
-        public const string ES_DO = "es-DO"; // Spanish - Dominican Republic
-        public const string ES_EC = "es-EC"; // Spanish - Ecuador
-        public const string ES_SV = "es-SV"; // Spanish - El Salvador
-        public const string ES_GT = "es-GT"; // Spanish - Guatemala
-        public const string ES_HN = "es-HN"; // Spanish - Honduras
-        public const string ES_MX = "es-MX"; // Spanish - Mexico
-        public const string ES_NI = "es-NI"; // Spanish - Nicaragua
-        public const string ES_PA = "es-PA"; // Spanish - Panama
-        public const string ES_PY = "es-PY"; // Spanish - Paraguay
-        public const string ES_PE = "es-PE"; // Spanish - Peru
-        public const string ES_PR = "es-PR"; // Spanish - Puerto Rico
-        public const string ES_ES = "es-ES"; // Spanish - Spain
-        public const string ES_UY = "es-UY"; // Spanish - Uruguay
-        public const string ES_VE = "es-VE"; // Spanish - Venezuela
-        public const string SW_KE = "sw-KE"; // Swahili - Kenya
-        public const string SV_FI = "sv-FI"; // Swedish - Finland
-        public const string SV_SE = "sv-SE"; // Swedish - Sweden
-        public const string SYR_SY = "syr-SY"; // Syriac - Syria
-        public const string TA_IN = "ta-IN"; // Tamil - India
-        public const string TT_RU = "tt-RU"; // Tatar - Russia
-        public const string TE_IN = "te-IN"; // Telugu - India
-        public const string TH_TH = "th-TH"; // Thai - Thailand
-        public const string TR_TR = "tr-TR"; // Turkish - Turkey
-        public const string UK_UA = "uk-UA"; // Ukrainian - Ukraine
-        public const string UR_PK = "ur-PK"; // Urdu - Pakistan
-        public const string CY_UZ_UZ = "Cy-uz-UZ"; // Uzbek (Cyrillic) - Uzbekistan
-        public const string LT_UZ_UZ = "Lt-uz-UZ"; // Uzbek (Latin) - Uzbekistan
-        public const string VI_VN = "vi-VN"; // Vietnamese - Vietnam
+        /// <summary>
+        /// Afrikaans - South Africa
+        /// </summary>
+        public const string AF_ZA = "af-ZA";
+
+        /// <summary>
+        /// Arabic - United Arab Emirates
+        /// </summary>
+        public const string AR_AE = "ar-AE";
+
+        /// <summary>
+        /// Arabic - Bahrain
+        /// </summary>
+        public const string AR_BH = "ar-BH";
+
+        /// <summary>
+        /// Arabic - Algeria
+        /// </summary>
+        public const string AR_DZ = "ar-DZ";
+
+        /// <summary>
+        /// Arabic - Egypt
+        /// </summary>
+        public const string AR_EG = "ar-EG";
+
+        /// <summary>
+        /// Arabic - Iraq
+        /// </summary>
+        public const string AR_IQ = "ar-IQ";
+
+        /// <summary>
+        /// Arabic - Jordan
+        /// </summary>
+        public const string AR_JO = "ar-JO";
+
+        /// <summary>
+        /// Arabic - Kuwait
+        /// </summary>
+        public const string AR_KW = "ar-KW";
+
+        /// <summary>
+        /// Arabic - Lebanon
+        /// </summary>
+        public const string AR_LB = "ar-LB";
+
+        /// <summary>
+        /// Arabic - Libya
+        /// </summary>
+        public const string AR_LY = "ar-LY";
+
+        /// <summary>
+        /// Arabic - Morocco
+        /// </summary>
+        public const string AR_MA = "ar-MA";
+
+        /// <summary>
+        /// Arabic - Oman
+        /// </summary>
+        public const string AR_OM = "ar-OM";
+
+        /// <summary>
+        /// Arabic - Qatar
+        /// </summary>
+        public const string AR_QA = "ar-QA";
+
+        /// <summary>
+        /// Arabic - Saudi Arabia
+        /// </summary>
+        public const string AR_SA = "ar-SA";
+
+        /// <summary>
+        /// Arabic - Syria
+        /// </summary>
+        public const string AR_SY = "ar-SY";
+
+        /// <summary>
+        /// Arabic - Tunisia
+        /// </summary>
+        public const string AR_TN = "ar-TN";
+
+        /// <summary>
+        /// Arabic - Yemen
+        /// </summary>
+        public const string AR_YE = "ar-YE";
+
+        /// <summary>
+        /// Belarusian - Belarus
+        /// </summary>
+        public const string BE_BY = "be-BY";
+
+        /// <summary>
+        /// Bulgarian - Bulgaria
+        /// </summary>
+        public const string BG_BG = "bg-BG";
+
+        /// <summary>
+        /// Catalan - Catalan
+        /// </summary>
+        public const string CA_ES = "ca-ES";
+
+        /// <summary>
+        /// Czech - Czech Republic
+        /// </summary>
+        public const string CS_CZ = "cs-CZ";
+
+        /// <summary>
+        /// Azeri (Cyrillic) - Azerbaijan
+        /// </summary>
+        public const string CY_AZ_AZ = "Cy-az-AZ";
+
+        /// <summary>
+        /// Serbian (Cyrillic) - Serbia
+        /// </summary>
+        public const string CY_SR_SP = "Cy-sr-SP";
+
+        /// <summary>
+        /// Uzbek (Cyrillic) - Uzbekistan
+        /// </summary>
+        public const string CY_UZ_UZ = "Cy-uz-UZ";
+
+        /// <summary>
+        /// Danish - Denmark
+        /// </summary>
+        public const string DA_DK = "da-DK";
+
+        /// <summary>
+        /// German - Austria
+        /// </summary>
+        public const string DE_AT = "de-AT";
+
+        /// <summary>
+        /// German - Switzerland
+        /// </summary>
+        public const string DE_CH = "de-CH";
+
+        /// <summary>
+        /// German - Germany
+        /// </summary>
+        public const string DE_DE = "de-DE";
+
+        /// <summary>
+        /// German - Liechtenstein
+        /// </summary>
+        public const string DE_LI = "de-LI";
+
+        /// <summary>
+        /// German - Luxembourg
+        /// </summary>
+        public const string DE_LU = "de-LU";
+
+        /// <summary>
+        /// Dhivehi - Maldives
+        /// </summary>
+        public const string DIV_MV = "div-MV";
+
+        /// <summary>
+        /// Greek - Greece
+        /// </summary>
+        public const string EL_GR = "el-GR";
+
+        /// <summary>
+        /// English - Australia
+        /// </summary>
+        public const string EN_AU = "en-AU";
+
+        /// <summary>
+        /// English - Belize
+        /// </summary>
+        public const string EN_BZ = "en-BZ";
+
+        /// <summary>
+        /// English - Canada
+        /// </summary>
+        public const string EN_CA = "en-CA";
+
+        /// <summary>
+        /// English - Caribbean
+        /// </summary>
+        public const string EN_CB = "en-CB";
+
+        /// <summary>
+        /// English - United Kingdom
+        /// </summary>
+        public const string EN_GB = "en-GB";
+
+        /// <summary>
+        /// English - Ireland
+        /// </summary>
+        public const string EN_IE = "en-IE";
+
+        /// <summary>
+        /// English - Jamaica
+        /// </summary>
+        public const string EN_JM = "en-JM";
+
+        /// <summary>
+        /// English - New Zealand
+        /// </summary>
+        public const string EN_NZ = "en-NZ";
+
+        /// <summary>
+        /// English - Philippines
+        /// </summary>
+        public const string EN_PH = "en-PH";
+
+        /// <summary>
+        /// English - Trinidad and Tobago
+        /// </summary>
+        public const string EN_TT = "en-TT";
+
+        /// <summary>
+        /// English - United States
+        /// </summary>
+        public const string EN_US = "en-US";
+
+        /// <summary>
+        /// English - South Africa
+        /// </summary>
+        public const string EN_ZA = "en-ZA";
+
+        /// <summary>
+        /// English - Zimbabwe
+        /// </summary>
+        public const string EN_ZW = "en-ZW";
+
+        /// <summary>
+        /// Spanish - Argentina
+        /// </summary>
+        public const string ES_AR = "es-AR";
+
+        /// <summary>
+        /// Spanish - Bolivia
+        /// </summary>
+        public const string ES_BO = "es-BO";
+
+        /// <summary>
+        /// Spanish - Chile
+        /// </summary>
+        public const string ES_CL = "es-CL";
+
+        /// <summary>
+        /// Spanish - Colombia
+        /// </summary>
+        public const string ES_CO = "es-CO";
+
+        /// <summary>
+        /// Spanish - Costa Rica
+        /// </summary>
+        public const string ES_CR = "es-CR";
+
+        /// <summary>
+        /// Spanish - Dominican Republic
+        /// </summary>
+        public const string ES_DO = "es-DO";
+
+        /// <summary>
+        /// Spanish - Ecuador
+        /// </summary>
+        public const string ES_EC = "es-EC";
+
+        /// <summary>
+        /// Spanish - Spain
+        /// </summary>
+        public const string ES_ES = "es-ES";
+
+        /// <summary>
+        /// Spanish - Guatemala
+        /// </summary>
+        public const string ES_GT = "es-GT";
+
+        /// <summary>
+        /// Spanish - Honduras
+        /// </summary>
+        public const string ES_HN = "es-HN";
+
+        /// <summary>
+        /// Spanish - Mexico
+        /// </summary>
+        public const string ES_MX = "es-MX";
+
+        /// <summary>
+        /// Spanish - Nicaragua
+        /// </summary>
+        public const string ES_NI = "es-NI";
+
+        /// <summary>
+        /// Spanish - Panama
+        /// </summary>
+        public const string ES_PA = "es-PA";
+
+        /// <summary>
+        /// Spanish - Peru
+        /// </summary>
+        public const string ES_PE = "es-PE";
+
+        /// <summary>
+        /// Spanish - Puerto Rico
+        /// </summary>
+        public const string ES_PR = "es-PR";
+
+        /// <summary>
+        /// Spanish - Paraguay
+        /// </summary>
+        public const string ES_PY = "es-PY";
+
+        /// <summary>
+        /// Spanish - El Salvador
+        /// </summary>
+        public const string ES_SV = "es-SV";
+
+        /// <summary>
+        /// Spanish - Uruguay
+        /// </summary>
+        public const string ES_UY = "es-UY";
+
+        /// <summary>
+        /// Spanish - Venezuela
+        /// </summary>
+        public const string ES_VE = "es-VE";
+
+        /// <summary>
+        /// Estonian - Estonia
+        /// </summary>
+        public const string ET_EE = "et-EE";
+
+        /// <summary>
+        /// Basque - Basque
+        /// </summary>
+        public const string EU_ES = "eu-ES";
+
+        /// <summary>
+        /// Farsi - Iran
+        /// </summary>
+        public const string FA_IR = "fa-IR";
+
+        /// <summary>
+        /// Finnish - Finland
+        /// </summary>
+        public const string FI_FI = "fi-FI";
+
+        /// <summary>
+        /// Faroese - Faroe Islands
+        /// </summary>
+        public const string FO_FO = "fo-FO";
+
+        /// <summary>
+        /// French - Belgium
+        /// </summary>
+        public const string FR_BE = "fr-BE";
+
+        /// <summary>
+        /// French - Canada
+        /// </summary>
+        public const string FR_CA = "fr-CA";
+
+        /// <summary>
+        /// French - Switzerland
+        /// </summary>
+        public const string FR_CH = "fr-CH";
+
+        /// <summary>
+        /// French - France
+        /// </summary>
+        public const string FR_FR = "fr-FR";
+
+        /// <summary>
+        /// French - Luxembourg
+        /// </summary>
+        public const string FR_LU = "fr-LU";
+
+        /// <summary>
+        /// French - Monaco
+        /// </summary>
+        public const string FR_MC = "fr-MC";
+
+        /// <summary>
+        /// Galician - Galician
+        /// </summary>
+        public const string GL_ES = "gl-ES";
+
+        /// <summary>
+        /// Gujarati - India
+        /// </summary>
+        public const string GU_IN = "gu-IN";
+
+        /// <summary>
+        /// Hebrew - Israel
+        /// </summary>
+        public const string HE_IL = "he-IL";
+
+        /// <summary>
+        /// Hindi - India
+        /// </summary>
+        public const string HI_IN = "hi-IN";
+
+        /// <summary>
+        /// Croatian - Croatia
+        /// </summary>
+        public const string HR_HR = "hr-HR";
+
+        /// <summary>
+        /// Hungarian - Hungary
+        /// </summary>
+        public const string HU_HU = "hu-HU";
+
+        /// <summary>
+        /// Armenian - Armenia
+        /// </summary>
+        public const string HY_AM = "hy-AM";
+
+        /// <summary>
+        /// Indonesian - Indonesia
+        /// </summary>
+        public const string ID_ID = "id-ID";
+
+        /// <summary>
+        /// Icelandic - Iceland
+        /// </summary>
+        public const string IS_IS = "is-IS";
+
+        /// <summary>
+        /// Italian - Switzerland
+        /// </summary>
+        public const string IT_CH = "it-CH";
+
+        /// <summary>
+        /// Italian - Italy
+        /// </summary>
+        public const string IT_IT = "it-IT";
+
+        /// <summary>
+        /// Japanese - Japan
+        /// </summary>
+        public const string JA_JP = "ja-JP";
+
+        /// <summary>
+        /// Georgian - Georgia
+        /// </summary>
+        public const string KA_GE = "ka-GE";
+
+        /// <summary>
+        /// Kazakh - Kazakhstan
+        /// </summary>
+        public const string KK_KZ = "kk-KZ";
+
+        /// <summary>
+        /// Kannada - India
+        /// </summary>
+        public const string KN_IN = "kn-IN";
+
+        /// <summary>
+        /// Korean - Korea
+        /// </summary>
+        public const string KO_KR = "ko-KR";
+
+        /// <summary>
+        /// Konkani - India
+        /// </summary>
+        public const string KOK_IN = "kok-IN";
+
+        /// <summary>
+        /// Kyrgyz - Kazakhstan
+        /// </summary>
+        public const string KY_KZ = "ky-KZ";
+
+        /// <summary>
+        /// Azeri (Latin) - Azerbaijan
+        /// </summary>
+        public const string LT_AZ_AZ = "Lt-az-AZ";
+
+        /// <summary>
+        /// Lithuanian - Lithuania
+        /// </summary>
+        public const string LT_LT = "lt-LT";
+
+        /// <summary>
+        /// Serbian (Latin) - Serbia
+        /// </summary>
+        public const string LT_SR_SP = "Lt-sr-SP";
+
+        /// <summary>
+        /// Uzbek (Latin) - Uzbekistan
+        /// </summary>
+        public const string LT_UZ_UZ = "Lt-uz-UZ";
+
+        /// <summary>
+        /// Latvian - Latvia
+        /// </summary>
+        public const string LV_LV = "lv-LV";
+
+        /// <summary>
+        /// Macedonian (FYROM)
+        /// </summary>
+        public const string MK_MK = "mk-MK";
+
+        /// <summary>
+        /// Mongolian - Mongolia
+        /// </summary>
+        public const string MN_MN = "mn-MN";
+
+        /// <summary>
+        /// Marathi - India
+        /// </summary>
+        public const string MR_IN = "mr-IN";
+
+        /// <summary>
+        /// Malay - Brunei
+        /// </summary>
+        public const string MS_BN = "ms-BN";
+
+        /// <summary>
+        /// Malay - Malaysia
+        /// </summary>
+        public const string MS_MY = "ms-MY";
+
+        /// <summary>
+        /// Norwegian (Bokmål) - Norway
+        /// </summary>
+        public const string NB_NO = "nb-NO";
+
+        /// <summary>
+        /// Dutch - Belgium
+        /// </summary>
+        public const string NL_BE = "nl-BE";
+
+        /// <summary>
+        /// Dutch - The Netherlands
+        /// </summary>
+        public const string NL_NL = "nl-NL";
+
+        /// <summary>
+        /// Norwegian (Nynorsk) - Norway
+        /// </summary>
+        public const string NN_NO = "nn-NO";
+
+        /// <summary>
+        /// Punjabi - India
+        /// </summary>
+        public const string PA_IN = "pa-IN";
+
+        /// <summary>
+        /// Polish - Poland
+        /// </summary>
+        public const string PL_PL = "pl-PL";
+
+        /// <summary>
+        /// Portuguese - Brazil
+        /// </summary>
+        public const string PT_BR = "pt-BR";
+
+        /// <summary>
+        /// Portuguese - Portugal
+        /// </summary>
+        public const string PT_PT = "pt-PT";
+
+        /// <summary>
+        /// Romanian - Romania
+        /// </summary>
+        public const string RO_RO = "ro-RO";
+
+        /// <summary>
+        /// Russian - Russia
+        /// </summary>
+        public const string RU_RU = "ru-RU";
+
+        /// <summary>
+        /// Sanskrit - India
+        /// </summary>
+        public const string SA_IN = "sa-IN";
+
+        /// <summary>
+        /// Slovak - Slovakia
+        /// </summary>
+        public const string SK_SK = "sk-SK";
+
+        /// <summary>
+        /// Slovenian - Slovenia
+        /// </summary>
+        public const string SL_SI = "sl-SI";
+
+        /// <summary>
+        /// Albanian - Albania
+        /// </summary>
+        public const string SQ_AL = "sq-AL";
+
+        /// <summary>
+        /// Swedish - Finland
+        /// </summary>
+        public const string SV_FI = "sv-FI";
+
+        /// <summary>
+        /// Swedish - Sweden
+        /// </summary>
+        public const string SV_SE = "sv-SE";
+
+        /// <summary>
+        /// Swahili - Kenya
+        /// </summary>
+        public const string SW_KE = "sw-KE";
+
+        /// <summary>
+        /// Syriac - Syria
+        /// </summary>
+        public const string SYR_SY = "syr-SY";
+
+        /// <summary>
+        /// Tamil - India
+        /// </summary>
+        public const string TA_IN = "ta-IN";
+
+        /// <summary>
+        /// Telugu - India
+        /// </summary>
+        public const string TE_IN = "te-IN";
+
+        /// <summary>
+        /// Thai - Thailand
+        /// </summary>
+        public const string TH_TH = "th-TH";
+
+        /// <summary>
+        /// Turkish - Turkey
+        /// </summary>
+        public const string TR_TR = "tr-TR";
+
+        /// <summary>
+        /// Tatar - Russia
+        /// </summary>
+        public const string TT_RU = "tt-RU";
+
+        /// <summary>
+        /// Ukrainian - Ukraine
+        /// </summary>
+        public const string UK_UA = "uk-UA";
+
+        /// <summary>
+        /// Urdu - Pakistan
+        /// </summary>
+        public const string UR_PK = "ur-PK";
+
+        /// <summary>
+        /// Vietnamese - Vietnam
+        /// </summary>
+        public const string VI_VN = "vi-VN";
+
+        /// <summary>
+        /// Chinese (Simplified)
+        /// </summary>
+        public const string ZH_CHS = "zh-CHS";
+
+        /// <summary>
+        /// Chinese (Traditional)
+        /// </summary>
+        public const string ZH_CHT = "zh-CHT";
+
+        /// <summary>
+        /// Chinese - China
+        /// </summary>
+        public const string ZH_CN = "zh-CN";
+
+        /// <summary>
+        /// Chinese - Hong Kong SAR
+        /// </summary>
+        public const string ZH_HK = "zh-HK";
+
+        /// <summary>
+        /// Chinese - Macau SAR
+        /// </summary>
+        public const string ZH_MO = "zh-MO";
+
+        /// <summary>
+        /// Chinese - Singapore
+        /// </summary>
+        public const string ZH_SG = "zh-SG";
+
+        /// <summary>
+        /// Chinese - Taiwan
+        /// </summary>
+        public const string ZH_TW = "zh-TW";
     }
 }


### PR DESCRIPTION
No new executable code here, mostly just adding in a key so it can be leveraged for other projects (AndcultureCode.CSharp.Web, AndcultureCode.CSharp.Testing)

Alphabetized & moved all locale comments in `Rfc4646LanguageCodes` to XML doc comments to reduce a large number of build warnings for missing comments. 