### PR TITLE
Updated LocalizationUtils to return default culture when calling Cult…

### DIFF
--- a/src/AndcultureCode.CSharp.Core/Utilities/Localization/LocalizationUtils.cs
+++ b/src/AndcultureCode.CSharp.Core/Utilities/Localization/LocalizationUtils.cs
@@ -71,7 +71,14 @@ namespace AndcultureCode.CSharp.Core.Utilities.Localization
         #region Public Methods
 
         public static ICulture CultureByCode(string cultureCode)
-            => Cultures.FirstOrDefault(e => e.Code.ToLower() == cultureCode.ToLower());
+        {
+            if (cultureCode == CultureInfo.InvariantCulture.Name)
+            {
+                return DefaultCulture;
+            }
+
+            return Cultures.FirstOrDefault(e => e.Code.ToLower() == cultureCode.ToLower());
+        }
 
         public static string CultureCodes(string delimiter = ", ")
             => Cultures.ToCultureCodes(delimiter);

--- a/test/AndcultureCode.CSharp.Core.Tests/Utilities/Localization/LocalizationUtilsTest.cs
+++ b/test/AndcultureCode.CSharp.Core.Tests/Utilities/Localization/LocalizationUtilsTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using AndcultureCode.CSharp.Core.Tests.Unit.Stubs;
 using AndcultureCode.CSharp.Core.Utilities.Localization;
 using AndcultureCode.CSharp.Testing;
@@ -114,6 +115,17 @@ namespace AndcultureCode.CSharp.Core.Tests.Unit.Utilities.Localization
         public void CultureByCode_Given_CultureCode_DoesNotExist_Returns_Null()
         {
             LocalizationUtils.CultureByCode("404").ShouldBeNull();
+        }
+
+        [Fact]
+        public void CultureByCode_Given_Invariant_CultureCode_Returns_Default_Culture()
+        {
+            // Act
+            var result = LocalizationUtils.CultureByCode(CultureInfo.InvariantCulture.Name);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Code.ShouldBe(LocalizationUtils.DefaultCultureCode);
         }
 
         [Fact]


### PR DESCRIPTION
Updated LocalizationUtils to return default culture when calling CultureByCode and passing in InvariantCulture. This fixes an object reference error that occurs when calling this method on a system where the culture is Invariant.

- [N/A] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [x] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
