### PR TITLE
Add/fix XML doc comments for Cultures - Issue #34

### DIFF
--- a/src/AndcultureCode.CSharp.Core/Cultures/EnglishUnitedStates.cs
+++ b/src/AndcultureCode.CSharp.Core/Cultures/EnglishUnitedStates.cs
@@ -3,9 +3,14 @@ using AndcultureCode.CSharp.Core.Models.Localization;
 
 namespace AndcultureCode.CSharp.Core.Cultures
 {
+    /// <summary>
+    /// Localization Culture for United States English (en-US)
+    /// </summary>
     public class EnglishUnitedStates : Culture
     {
+        /// <inheritdoc/>
         public override string Code { get => Rfc4646LanguageCodes.EN_US; }
+        /// <inheritdoc/>
         public override bool IsDefault => true;
     }
 }

--- a/src/AndcultureCode.CSharp.Core/Cultures/SpanishSpain.cs
+++ b/src/AndcultureCode.CSharp.Core/Cultures/SpanishSpain.cs
@@ -3,8 +3,12 @@ using AndcultureCode.CSharp.Core.Models.Localization;
 
 namespace AndcultureCode.CSharp.Core.Cultures
 {
+    /// <summary>
+    /// Localization Culture for Spanish - Spain (es-US)
+    /// </summary>
     public class SpanishSpain : Culture
     {
+        /// <inheritdoc/>
         public override string Code { get => Rfc4646LanguageCodes.ES_ES; }
     }
 }


### PR DESCRIPTION
# Description
Add XML doc comments for English-US and Spanish-ES cultures.

Resolves issue #34 

# Task List

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [ ] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
